### PR TITLE
Rebuild local admin if the current master host is down

### DIFF
--- a/cluster/reconcile.go
+++ b/cluster/reconcile.go
@@ -17,13 +17,6 @@ func ReconcileCluster(kubeCluster, currentCluster *Cluster) error {
 
 		return nil
 	}
-	// to handle if current local admin is down and we need to use new cp from the list
-	if !isLocalConfigWorking(kubeCluster.LocalKubeConfigPath) {
-		if err := rebuildLocalAdminConfig(kubeCluster); err != nil {
-			return err
-		}
-	}
-
 	kubeClient, err := k8s.NewClient(kubeCluster.LocalKubeConfigPath)
 	if err != nil {
 		return fmt.Errorf("Failed to initialize new kubernetes client: %v", err)

--- a/cluster/state.go
+++ b/cluster/state.go
@@ -38,6 +38,13 @@ func (c *Cluster) GetClusterState() (*Cluster, error) {
 	if _, err = os.Stat(c.LocalKubeConfigPath); !os.IsNotExist(err) {
 		logrus.Infof("[state] Found local kube config file, trying to get state from cluster")
 
+		// to handle if current local admin is down and we need to use new cp from the list
+		if !isLocalConfigWorking(c.LocalKubeConfigPath) {
+			if err := rebuildLocalAdminConfig(c); err != nil {
+				return nil, err
+			}
+		}
+
 		// initiate kubernetes client
 		c.KubeClient, err = k8s.NewClient(c.LocalKubeConfigPath)
 		if err != nil {


### PR DESCRIPTION
#113 

If the current cp host is unreachable, rke will try each cp host in the list until it finds one that is working and use it to get cluster state.