### PR TITLE
Update README.md (cluster.yaml -> cluster.yml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ usermod -aG docker <user_name>
 
 Standing up a Kubernetes is as simple as creating a `cluster.yml` configuration file and and running the command:
 ```bash
-./rke up --config cluster.yaml
+./rke up --config cluster.yml
 ```
-### Full `cluster.yaml` example
+### Full `cluster.yml` example
 
 You can view full sample of cluster.yml [here](https://github.com/rancher/rke/blob/master/cluster.yml).
 
-### Minimal `cluster.yaml` example
+### Minimal `cluster.yml` example
 ```
 nodes:
   - address: 1.1.1.1


### PR DESCRIPTION
The default file name is cluster.yml, but in documentation examples it's cluster.yaml, which makes overall setup process to be not that smooth as it could be.