### PR TITLE
Added no-swap for kubelet node comment in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ usermod -aG docker <user_name>
 ```
 
 - Ports 6443, 2379, and 2380 should be opened between cluster nodes.
+- Swap disabled on worker nodes.
 
 ## Getting Started
 


### PR DESCRIPTION
To avoid `error: failed to run Kubelet: Running with swap on is not supported, please disable swap! or set --fail-swap-on flag to false.` error.

Although there is a workaround as stated in https://github.com/rancher/rke/issues/189#issuecomment-354661774 running without swap is preferred as discussed in https://github.com/kubernetes/kubernetes/issues/53533#issuecomment-334947625 and should be mentioned. 