### PR TITLE
Fix to partially address Issue #303

### DIFF
--- a/templates/job-deployer.go
+++ b/templates/job-deployer.go
@@ -9,6 +9,7 @@ kind: Job
 metadata:
   name: {{$addonName}}-deploy-job
 spec:
+  backoffLimit: 10
   template:
     metadata:
        name: pi


### PR DESCRIPTION
Environment sometimes taking time to get stabilized..  

Initial Error
```
Failed to download OpenAPI (Get https://10.233.0.1:443/swagger-2.0.0.pb-v1: dial tcp 10.233.0.1:443: i/o timeout), falling back to swagger
Unable to connect to the server: dial tcp 10.233.0.1:443: i/o timeout
```

Eventually networking is working but taking time.. but by that time jobs are hitting backoffLimit and no executed. 

The back-off limit of K8 JOB is set default to 6 by K8s . with exponential back-off delay (10s, 20s, 40s …) capped at six minutes. 

So Setting 10 will allow sometime for job to get executed 

Partial fix for https://github.com/rancher/rke/issues/303