### PR TITLE
Support Cluster name in Kube Config

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -132,6 +132,10 @@ ignore_docker_version: false
 
 kubernetes_version: v1.8.9-rancher1-1
 
+# If set, this is the cluster name that will be used in the kube config file
+# Default value is "local"
+cluster_name: mycluster
+
 # List of registry credentials, if you are using a Docker Hub registry,
 # you can omit the `url` or set it to `docker.io`
 private_registries:

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -180,13 +180,13 @@ func rebuildLocalAdminConfig(ctx context.Context, kubeCluster *Cluster) error {
 	for _, cpHost := range kubeCluster.ControlPlaneHosts {
 		if (currentKubeConfig == pki.CertificatePKI{}) {
 			kubeCluster.Certificates = make(map[string]pki.CertificatePKI)
-			newConfig = getLocalAdminConfigWithNewAddress(kubeCluster.LocalKubeConfigPath, cpHost.Address)
+			newConfig = getLocalAdminConfigWithNewAddress(kubeCluster.LocalKubeConfigPath, cpHost.Address, kubeCluster.ClusterName)
 		} else {
 			kubeURL := fmt.Sprintf("https://%s:6443", cpHost.Address)
 			caData := string(cert.EncodeCertPEM(caCrt))
 			crtData := string(cert.EncodeCertPEM(currentKubeConfig.Certificate))
 			keyData := string(cert.EncodePrivateKeyPEM(currentKubeConfig.Key))
-			newConfig = pki.GetKubeConfigX509WithData(kubeURL, pki.KubeAdminCertName, caData, crtData, keyData)
+			newConfig = pki.GetKubeConfigX509WithData(kubeURL, kubeCluster.ClusterName, pki.KubeAdminCertName, caData, crtData, keyData)
 		}
 		if err := pki.DeployAdminConfig(ctx, newConfig, kubeCluster.LocalKubeConfigPath); err != nil {
 			return fmt.Errorf("Failed to redeploy local admin config with new host")
@@ -220,7 +220,7 @@ func getLocalConfigAddress(localConfigPath string) (string, error) {
 	return address[2:], nil
 }
 
-func getLocalAdminConfigWithNewAddress(localConfigPath, cpAddress string) string {
+func getLocalAdminConfigWithNewAddress(localConfigPath, cpAddress string, clusterName string) string {
 	config, _ := clientcmd.BuildConfigFromFlags("", localConfigPath)
 	if config == nil {
 		return ""
@@ -228,6 +228,7 @@ func getLocalAdminConfigWithNewAddress(localConfigPath, cpAddress string) string
 	config.Host = fmt.Sprintf("https://%s:6443", cpAddress)
 	return pki.GetKubeConfigX509WithData(
 		"https://"+cpAddress+":6443",
+		clusterName,
 		pki.KubeAdminCertName,
 		string(config.CAData),
 		string(config.CertData),

--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -14,6 +14,7 @@ const (
 	DefaultClusterCIDR           = "10.233.64.0/18"
 	DefaultClusterDNSService     = "10.233.0.3"
 	DefaultClusterDomain         = "cluster.local"
+	DefaultClusterName           = "local"
 	DefaultClusterSSHKeyPath     = "~/.ssh/id_rsa"
 
 	DefaultK8sVersion = v3.K8sV18
@@ -75,6 +76,9 @@ func (c *Cluster) setClusterDefaults(ctx context.Context) {
 	}
 	if len(c.Ingress.Provider) == 0 {
 		c.Ingress.Provider = DefaultIngressController
+	}
+	if len(c.ClusterName) == 0 {
+		c.ClusterName = DefaultClusterName
 	}
 
 	c.setClusterImageDefaults()

--- a/pki/kubeconfig.go
+++ b/pki/kubeconfig.go
@@ -2,7 +2,7 @@ package pki
 
 import "encoding/base64"
 
-func getKubeConfigX509(kubernetesURL string, componentName string, caPath string, crtPath string, keyPath string) string {
+func getKubeConfigX509(kubernetesURL string, clusterName string, componentName string, caPath string, crtPath string, keyPath string) string {
 	return `apiVersion: v1
 kind: Config
 clusters:
@@ -10,10 +10,10 @@ clusters:
     api-version: v1
     certificate-authority: ` + caPath + `
     server: "` + kubernetesURL + `"
-  name: "local"
+  name: "` + clusterName + `"
 contexts:
 - context:
-    cluster: "local"
+    cluster: "` + clusterName + `"
     user: "` + componentName + `"
   name: "Default"
 current-context: "Default"
@@ -24,7 +24,7 @@ users:
     client-key: ` + keyPath + ``
 }
 
-func GetKubeConfigX509WithData(kubernetesURL string, componentName string, cacrt string, crt string, key string) string {
+func GetKubeConfigX509WithData(kubernetesURL string, clusterName string, componentName string, cacrt string, crt string, key string) string {
 	return `apiVersion: v1
 kind: Config
 clusters:
@@ -32,10 +32,10 @@ clusters:
     api-version: v1
     certificate-authority-data: ` + base64.StdEncoding.EncodeToString([]byte(cacrt)) + `
     server: "` + kubernetesURL + `"
-  name: "local"
+  name: "` + clusterName + `"
 contexts:
 - context:
-    cluster: "local"
+    cluster: "` + clusterName + `"
     user: "` + componentName + `"
   name: "Default"
 current-context: "Default"

--- a/pki/pki.go
+++ b/pki/pki.go
@@ -105,6 +105,7 @@ func GenerateRKECerts(ctx context.Context, rkeConfig v3.RancherKubernetesEngineC
 	if len(cpHosts) > 0 {
 		kubeAdminConfig := GetKubeConfigX509WithData(
 			"https://"+cpHosts[0].Address+":6443",
+			rkeConfig.ClusterName,
 			KubeAdminCertName,
 			string(cert.EncodeCertPEM(caCrt)),
 			string(cert.EncodeCertPEM(kubeAdminCrt)),

--- a/pki/util.go
+++ b/pki/util.go
@@ -188,7 +188,7 @@ func ToCertObject(componentName, commonName, ouName string, cert *x509.Certifica
 	keyPath := GetKeyPath(componentName)
 
 	if componentName != CACertName && componentName != KubeAPICertName && !strings.Contains(componentName, EtcdCertName) {
-		config = getKubeConfigX509("https://127.0.0.1:6443", componentName, caCertPath, path, keyPath)
+		config = getKubeConfigX509("https://127.0.0.1:6443", "local", componentName, caCertPath, path, keyPath)
 		configPath = GetConfigPath(componentName)
 		configEnvName = getConfigEnvFromEnv(envName)
 	}


### PR DESCRIPTION
Requires vendor bump: types.
Depends on: https://github.com/rancher/types/pull/288

This PR solves #415 