### PR TITLE
Error out on unsuppored docker version instead of Warn

### DIFF
--- a/cluster/hosts.go
+++ b/cluster/hosts.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"strings"
 
 	"context"
 
@@ -31,6 +32,10 @@ func (c *Cluster) TunnelHosts(ctx context.Context, local bool) error {
 	uniqueHosts := hosts.GetUniqueHostList(c.EtcdHosts, c.ControlPlaneHosts, c.WorkerHosts)
 	for i := range uniqueHosts {
 		if err := uniqueHosts[i].TunnelUp(ctx, c.DockerDialerFactory); err != nil {
+			// Unsupported Docker version is NOT a connectivity problem that we can't recover! So we bail out on it
+			if strings.Contains(err.Error(), "Unsupported Docker version found") {
+				return err
+			}
 			log.Warnf(ctx, "Failed to set up SSH tunneling for host [%s]: %v", uniqueHosts[i].Address, err)
 			c.InactiveHosts = append(c.InactiveHosts, uniqueHosts[i])
 		}


### PR DESCRIPTION
Fixes a regression caused by how we handle connectivity failure. To handle temporary node connectivity issues we recently changed RKE behavior to just warn on connectivity problems and ignore the host for this run. 

However, this is not the expected behavior when we fail due to unsupported version when used with rancher. Since the proper error is not returned to rancher and the failure cause is not clear. So, this PR will exit with an error if the used docker version is not supported.

https://github.com/rancher/rancher/issues/12147
