### PR TITLE
Add additional hosts to Api Server PKI

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,18 @@ services:
       - "/usr/libexec/kubernetes/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins:z"
 ```
 
+## Authentication
+
+RKE Supports x509 authentication strategy. You can additionally define a list of SANs (Subject Alternative Names) to add to the Kubernetes API Server PKI certificates. This allows you to connect to your Kubernetes cluster API Server through a load balancer, for example, rather than a single node.
+
+```yaml
+authentication:
+  strategy: x509
+  sans:
+  - "10.18.160.10"
+  - "my-loadbalancer-1234567890.us-west-2.elb.amazonaws.com"
+```
+
 ## External etcd
 
 RKE supports using external etcd instead of deploying etcd servers, to enable external etcd the following parameters should be populated:

--- a/cluster.yml
+++ b/cluster.yml
@@ -86,8 +86,15 @@ network:
   plugin: flannel
   options:
 
+# At the moment, the only authentication strategy supported is x509.
+# You can optionally create additional SANs (hostnames or IPs) to add to
+#  the API server PKI certificate. This is useful if you want to use a load balancer
+#  for the control plane servers, for example.
 authentication:
   strategy: x509
+  sans:
+  - "10.18.160.10"
+  - "my-loadbalancer-1234567890.us-west-2.elb.amazonaws.com"
 
 # all addon manifests MUST specify a namespace
 addons: |-

--- a/cluster/certificates.go
+++ b/cluster/certificates.go
@@ -65,7 +65,7 @@ func SetUpAuthentication(ctx context.Context, kubeCluster, currentCluster *Clust
 
 func regenerateAPICertificate(c *Cluster, certificates map[string]pki.CertificatePKI) (map[string]pki.CertificatePKI, error) {
 	logrus.Debugf("[certificates] Regenerating kubeAPI certificate")
-	kubeAPIAltNames := pki.GetAltNames(c.ControlPlaneHosts, c.ClusterDomain, c.KubernetesServiceIP)
+	kubeAPIAltNames := pki.GetAltNames(c.ControlPlaneHosts, c.ClusterDomain, c.KubernetesServiceIP, c.Authentication.SANs)
 	caCrt := certificates[pki.CACertName].Certificate
 	caKey := certificates[pki.CACertName].Key
 	kubeAPIKey := certificates[pki.KubeAPICertName].Key

--- a/pki/pki.go
+++ b/pki/pki.go
@@ -52,7 +52,7 @@ func GenerateRKECerts(ctx context.Context, rkeConfig v3.RancherKubernetesEngineC
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get Kubernetes Service IP: %v", err)
 	}
-	kubeAPIAltNames := GetAltNames(cpHosts, clusterDomain, kubernetesServiceIP)
+	kubeAPIAltNames := GetAltNames(cpHosts, clusterDomain, kubernetesServiceIP, rkeConfig.Authentication.SANs)
 	kubeAPICrt, kubeAPIKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, KubeAPICertName, kubeAPIAltNames, nil, nil)
 	if err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ func GenerateRKECerts(ctx context.Context, rkeConfig v3.RancherKubernetesEngineC
 		certs[EtcdClientCACertName] = ToCertObject(EtcdClientCACertName, "", "", caCert[0], nil)
 	}
 	etcdHosts := hosts.NodesToHosts(rkeConfig.Nodes, etcdRole)
-	etcdAltNames := GetAltNames(etcdHosts, clusterDomain, kubernetesServiceIP)
+	etcdAltNames := GetAltNames(etcdHosts, clusterDomain, kubernetesServiceIP, []string{})
 	for _, host := range etcdHosts {
 		log.Infof(ctx, "[certificates] Generating etcd-%s certificate and key", host.InternalAddress)
 		etcdCrt, etcdKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, EtcdCertName, etcdAltNames, nil, nil)
@@ -196,7 +196,7 @@ func RegenerateEtcdCertificate(
 	log.Infof(ctx, "[certificates] Regenerating new etcd-%s certificate and key", etcdHost.InternalAddress)
 	caCrt := crtMap[CACertName].Certificate
 	caKey := crtMap[CACertName].Key
-	etcdAltNames := GetAltNames(etcdHosts, clusterDomain, KubernetesServiceIP)
+	etcdAltNames := GetAltNames(etcdHosts, clusterDomain, KubernetesServiceIP, []string{})
 
 	etcdCrt, etcdKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, EtcdCertName, etcdAltNames, nil, nil)
 	if err != nil {

--- a/pki/util.go
+++ b/pki/util.go
@@ -67,7 +67,7 @@ func generateCACertAndKey() (*x509.Certificate, *rsa.PrivateKey, error) {
 	return kubeCACert, rootKey, nil
 }
 
-func GetAltNames(cpHosts []*hosts.Host, clusterDomain string, KubernetesServiceIP net.IP) *cert.AltNames {
+func GetAltNames(cpHosts []*hosts.Host, clusterDomain string, KubernetesServiceIP net.IP, SANs []string) *cert.AltNames {
 	ips := []net.IP{}
 	dnsNames := []string{}
 	for _, host := range cpHosts {
@@ -91,6 +91,16 @@ func GetAltNames(cpHosts []*hosts.Host, clusterDomain string, KubernetesServiceI
 			dnsNames = append(dnsNames, host.HostnameOverride)
 		}
 	}
+
+	for _, host := range SANs {
+		// Check if node address is a valid IP
+		if nodeIP := net.ParseIP(host); nodeIP != nil {
+			ips = append(ips, nodeIP)
+		} else {
+			dnsNames = append(dnsNames, host)
+		}
+	}
+
 	ips = append(ips, net.ParseIP("127.0.0.1"))
 	ips = append(ips, KubernetesServiceIP)
 	dnsNames = append(dnsNames, []string{

--- a/vendor.conf
+++ b/vendor.conf
@@ -24,4 +24,4 @@ github.com/coreos/go-semver              e214231b295a8ea9479f11b70b35d5acf3556d9
 github.com/ugorji/go/codec               ccfe18359b55b97855cee1d3f74e5efbda4869dc
 
 github.com/rancher/norman                151aa66e3e99de7e0d195e2d5ca96b1f95544555
-github.com/rancher/types                 a9178824cd518e1ac2bd8efd03751437ddc1c1fe
+github.com/rancher/types                 c8a2bab012799603994eba13f59098c368350b27

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
@@ -224,6 +224,8 @@ type AuthnConfig struct {
 	Strategy string `yaml:"strategy" json:"strategy,omitempty"`
 	// Authentication options
 	Options map[string]string `yaml:"options" json:"options,omitempty"`
+	// List of additional hostnames and IPs to include in the api server PKI cert
+	SANs []string `yaml:"sans" json:"sans,omitempty"`
 }
 
 type AuthzConfig struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -1085,6 +1085,11 @@ func (in *AuthnConfig) DeepCopyInto(out *AuthnConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.SANs != nil {
+		in, out := &in.SANs, &out.SANs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Support the ability to add additional hosts or IPs (Alt Names) to the PKI certs for Kube Api server.

Satisfies #86 

Depends on types: https://github.com/rancher/types/pull/305
