### PR TITLE
Support for node config from docker-machine

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"strconv"
 	"strings"
 
+	"encoding/json"
+	"github.com/pkg/errors"
 	"github.com/rancher/rke/cluster"
 	"github.com/rancher/rke/pki"
 	"github.com/rancher/rke/services"
@@ -40,6 +43,10 @@ func ConfigCommand() cli.Command {
 			cli.BoolFlag{
 				Name:  "print,p",
 				Usage: "Print configuration",
+			},
+			cli.BoolFlag{
+				Name:  "from-machine,m",
+				Usage: "Get node configuration from docker-machine",
 			},
 		},
 	}
@@ -100,26 +107,35 @@ func clusterConfig(ctx *cli.Context) error {
 	}
 	cluster.SSHKeyPath = sshKeyPath
 
-	// Get number of hosts
-	numberOfHostsString, err := getConfig(reader, "Number of Hosts", "1")
-	if err != nil {
-		return err
-	}
-	numberOfHostsInt, err := strconv.Atoi(numberOfHostsString)
-	if err != nil {
-		return err
-	}
-
-	// Get Hosts config
 	cluster.Nodes = make([]v3.RKEConfigNode, 0)
-	for i := 0; i < numberOfHostsInt; i++ {
-		hostCfg, err := getHostConfig(reader, i, cluster.SSHKeyPath)
+	if ctx.Bool("from-machine") {
+		nodes, err := configureFromMachine(reader)
+
 		if err != nil {
 			return err
 		}
-		cluster.Nodes = append(cluster.Nodes, *hostCfg)
-	}
+		cluster.Nodes = append(cluster.Nodes, nodes...)
+	} else {
 
+		// Get number of hosts
+		numberOfHostsString, err := getConfig(reader, "Number of Hosts", "1")
+		if err != nil {
+			return err
+		}
+		numberOfHostsInt, err := strconv.Atoi(numberOfHostsString)
+		if err != nil {
+			return err
+		}
+
+		// Get Hosts config
+		for i := 0; i < numberOfHostsInt; i++ {
+			hostCfg, err := getHostConfig(reader, i, cluster.SSHKeyPath)
+			if err != nil {
+				return err
+			}
+			cluster.Nodes = append(cluster.Nodes, *hostCfg)
+		}
+	}
 	// Get Network config
 	networkConfig, err := getNetworkConfig(reader)
 	if err != nil {
@@ -336,4 +352,138 @@ func getNetworkConfig(reader *bufio.Reader) (*v3.NetworkConfig, error) {
 	}
 	networkConfig.Plugin = networkPlugin
 	return &networkConfig, nil
+}
+
+type NodeMachineConfig struct {
+	ConfigVersion int `json:"ConfigVersion,omitempty"`
+	Driver        struct {
+		IPAddress  string `json:"IPAddress,omitempty"`
+		SSHKeyPair string `json:"SSHKeyPair,omitempty"`
+		SSHKeyPath string `json:"SSHKeyPath,omitempty"`
+		SSHPort    int    `json:"SSHPort,omitempty"`
+		SSHUser    string `json:"SSHUser,omitempty"`
+	} `json:"Driver,omitempty"`
+	HostOptions struct {
+		EngineOptions struct {
+			Labels []string `json:"Labels,omitempty"`
+		} `json:"EngineOptions,omitempty"`
+	}
+	Name string `json:"Name,omitempty"`
+}
+
+func configureFromMachine(reader *bufio.Reader) ([]v3.RKEConfigNode, error) {
+	usr, err := user.Current()
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the docker-machine store path
+	machineStorePath, err := getConfig(reader, "Docker Machine storage path",
+		fmt.Sprintf("%s/.docker/machine/machines", usr.HomeDir))
+
+	if err != nil {
+		return nil, err
+	}
+
+	machines, err := getMachines(machineStorePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	selectedNodes, err := getConfig(reader, "Which nodes would you like to use", strings.Join(machines, ","))
+	if err != nil {
+		return nil, err
+	}
+	nodes := make([]v3.RKEConfigNode, 0)
+	for _, m := range strings.Split(selectedNodes, ",") {
+		node, err := getMachineConfig(machineStorePath, m)
+
+		if err != nil {
+			return nil, err
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes, nil
+}
+
+func getMachines(storePath string) ([]string, error) {
+	var machines []string
+	dirs, err := ioutil.ReadDir(storePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, d := range dirs {
+		machines = append(machines, d.Name())
+	}
+
+	return machines, nil
+}
+
+func getMachineConfig(storePath, machine string) (v3.RKEConfigNode, error) {
+	nodeConfig := v3.RKEConfigNode{}
+	configPath := fmt.Sprintf("%s/%s/config.json", storePath, machine)
+	configFile, err := ioutil.ReadFile(configPath)
+
+	if err != nil {
+		return nodeConfig, err
+	}
+
+	config := &NodeMachineConfig{}
+
+	if err := json.Unmarshal(configFile, config); err != nil {
+		return nodeConfig, err
+	}
+
+	if config.Driver.IPAddress == "" {
+		return nodeConfig, errors.New(fmt.Sprintf("IPAddress not defined in config.json for %s. "+
+			"Please ensure that the driver is setting these values correctly", machine))
+	}
+
+	nodeConfig.Role = getRolesFromLabels(config)
+	nodeConfig.SSHKeyPath = config.Driver.SSHKeyPath
+	nodeConfig.User = config.Driver.SSHUser
+	nodeConfig.Address = config.Driver.IPAddress
+	nodeConfig.Port = strconv.Itoa(config.Driver.SSHPort)
+
+	return nodeConfig, nil
+}
+
+func getRolesFromLabels(conf *NodeMachineConfig) []string {
+	var nodeRoles []string
+	labels := conf.HostOptions.EngineOptions.Labels
+
+	if len(labels) == 0 {
+		return append(nodeRoles, "worker", "controlplane", "etcd")
+	}
+
+	// Parse the labels and determine roles
+	for _, l := range labels {
+		if strings.ContainsAny(l, "worker controlplane etcd") {
+			label := strings.Split(l, "=")
+			ok, err := strconv.ParseBool(label[1])
+
+			if err != nil {
+				logrus.Infof("[config] Could not parse bool from label %s", label[0])
+				continue
+			}
+
+			if ok {
+				nodeRoles = append(nodeRoles, label[0])
+			}
+
+		}
+	}
+
+	if len(nodeRoles) == 0 {
+		nodeRoles = append(nodeRoles, "worker", "controlplane", "etcd")
+	}
+
+	return nodeRoles
+
 }


### PR DESCRIPTION
This would enable users to import docker-machine node configs during the `rke config` by adding the `--from-machine` or `-m`. In case a user has changed the docker-machine store-path (/home/$USER/.docker/machine/machines) it also prompts for the location. The next step is to provide a comma separated list of the machines to use for the nodes. 
```
# rke config -m
[+] Cluster Level SSH Private Key Path [~/.ssh/id_rsa]: 
[+] Docker Machine storage path [/home/dhendel/.docker/machine/machines]: 
[+] Which nodes would you like to use [rk8s01,rk8s02,rk8s03,rk8s04]: rk8s01,rk8s02,rk8s03,rk8s04
```

It reads the config.json for the node data using the following struct:
```go
type NodeMachineConfig struct {
	ConfigVersion int `json:"ConfigVersion,omitempty"`
	Driver        struct {
		IPAddress  string `json:"IPAddress,omitempty"`
		SSHKeyPair string `json:"SSHKeyPair,omitempty"`
		SSHKeyPath string `json:"SSHKeyPath,omitempty"`
		SSHPort    int    `json:"SSHPort,omitempty"`
		SSHUser    string `json:"SSHUser,omitempty"`
	} `json:"Driver,omitempty"`
	HostOptions struct {
		EngineOptions struct {
			Labels []string `json:"Labels,omitempty"`
		} `json:"EngineOptions,omitempty"`
	}
	Name string `json:"Name,omitempty"`
}
```
For now I have included the type in the config.go. Wasn't sure if there was anything in ranhcer/types that I could use to read the config data. 

This option also assumes that labels were passed to the engine and reads them to configure the node:
   - worker=[true|false]
   - controlplane=[true|false]
   - etcd=[true|false]

If no labels are passed it assumes the node will have all roles, this of course could be changed once the config is generated.