### PR TITLE
Add external Cloud Provider support

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -91,7 +91,6 @@ func (c *Cluster) BuildKubeAPIProcess() v3.Process {
 		"bind-address":                    "0.0.0.0",
 		"insecure-port":                   "0",
 		"secure-port":                     "6443",
-		"cloud-provider":                  c.CloudProvider.Name,
 		"allow-privileged":                "true",
 		"kubelet-preferred-address-types": "InternalIP,ExternalIP,Hostname",
 		"service-cluster-ip-range":        c.Services.KubeAPI.ServiceClusterIPRange,
@@ -104,7 +103,8 @@ func (c *Cluster) BuildKubeAPIProcess() v3.Process {
 		"kubelet-client-key":              pki.GetKeyPath(pki.KubeAPICertName),
 		"service-account-key-file":        pki.GetKeyPath(pki.KubeAPICertName),
 	}
-	if len(c.CloudProvider.Name) > 0 {
+	if len(c.CloudProvider.Name) > 0 && c.CloudProvider.Name != "external" {
+		CommandArgs["cloud-provider"] = c.CloudProvider.Name
 		CommandArgs["cloud-config"] = CloudConfigPath
 	}
 	args := []string{
@@ -168,7 +168,6 @@ func (c *Cluster) BuildKubeControllerProcess() v3.Process {
 
 	CommandArgs := map[string]string{
 		"address":                     "0.0.0.0",
-		"cloud-provider":              c.CloudProvider.Name,
 		"allow-untagged-cloud":        "true",
 		"configure-cloud-routes":      "false",
 		"leader-elect":                "true",
@@ -183,7 +182,8 @@ func (c *Cluster) BuildKubeControllerProcess() v3.Process {
 		"service-account-private-key-file": pki.GetKeyPath(pki.KubeAPICertName),
 		"root-ca-file":                     pki.GetCertPath(pki.CACertName),
 	}
-	if len(c.CloudProvider.Name) > 0 {
+	if len(c.CloudProvider.Name) > 0 && c.CloudProvider.Name != "external" {
+		CommandArgs["cloud-provider"] = c.CloudProvider.Name
 		CommandArgs["cloud-config"] = CloudConfigPath
 	}
 	args := []string{}
@@ -259,7 +259,7 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host) v3.Process {
 	if host.Address != host.InternalAddress {
 		CommandArgs["node-ip"] = host.InternalAddress
 	}
-	if len(c.CloudProvider.Name) > 0 {
+	if len(c.CloudProvider.Name) > 0 && c.CloudProvider.Name != "external" {
 		CommandArgs["cloud-config"] = CloudConfigPath
 	}
 	VolumesFrom := []string{

--- a/templates/calico.go
+++ b/templates/calico.go
@@ -176,6 +176,9 @@ spec:
         - key: "node-role.kubernetes.io/etcd"
           operator: "Exists"
           effect: "NoExecute"
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+          effect: NoSchedule
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/templates/flannel.go
+++ b/templates/flannel.go
@@ -148,6 +148,9 @@ spec:
           mountPath: /host/opt/cni/bin/
       hostNetwork: true
       tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule

--- a/templates/kubedns.go
+++ b/templates/kubedns.go
@@ -114,6 +114,9 @@ spec:
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
       volumes:
       - name: kube-dns-config
         configMap:

--- a/templates/weave.go
+++ b/templates/weave.go
@@ -89,6 +89,9 @@ items:
           tolerations:
             - effect: NoExecute
               operator: Exists
+            - key: node.cloudprovider.kubernetes.io/uninitialized
+              value: "true"
+              effect: NoSchedule
           volumes:
             - name: weavedb
               hostPath:


### PR DESCRIPTION
Support the ability to use external cloud-provider.

To use the external cloud provider, we need to do as follows.

- `kube-apiserver` and `kube-controller-manager` MUST NOT specify the --cloud-provider flag
- `kubelet` must run with --cloud-provider=external

> ref: [Kubernetes Document: Running cloud-controller-manager](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager)

so this PR will adds processing for these.

Also, kubelets specifying --cloud-provider=external will add a taint `node.cloudprovider.kubernetes.io/uninitialized` with an effect NoSchedule during initialization.

`kube-dns` and network plugins can not be started due to this effect, so this PR adds `tolerations` to each templates.
Only the canal template already had `tolerations`, so I did not modify it.

> ref: https://github.com/rancher/rke/blob/master/templates/canal.go#L210-L214)