### PR TITLE
Fix missing image for etcd only nodes

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -100,10 +100,10 @@ func (c *Cluster) DeployWorkerPlane(ctx context.Context) error {
 	// Deploy Worker plane
 	workerNodePlanMap := make(map[string]v3.RKEConfigNodePlan)
 	// Build cp node plan map
-	for _, workerHost := range c.ControlPlaneHosts {
+	allHosts := hosts.GetUniqueHostList(c.EtcdHosts, c.ControlPlaneHosts, c.WorkerHosts)
+	for _, workerHost := range allHosts {
 		workerNodePlanMap[workerHost.Address] = BuildRKEConfigNodePlan(ctx, c, workerHost, workerHost.DockerInfo)
 	}
-	allHosts := hosts.GetUniqueHostList(c.EtcdHosts, c.ControlPlaneHosts, c.WorkerHosts)
 	if err := services.RunWorkerPlane(ctx, allHosts,
 		c.LocalConnDialerFactory,
 		c.PrivateRegistriesMap,

--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -48,7 +48,7 @@ func BuildRKEConfigNodePlan(ctx context.Context, myCluster *Cluster, host *hosts
 
 	portChecks = append(portChecks, BuildPortChecksFromPortList(host, WorkerPortList, ProtocolTCP)...)
 	// Do we need an nginxProxy for this one ?
-	if host.IsWorker && !host.IsControl {
+	if !host.IsControl {
 		processes[services.NginxProxyContainerName] = myCluster.BuildProxyProcess()
 	}
 	if host.IsControl {


### PR DESCRIPTION
There seemed to be two issues here.  First, the workerNodePlanMap would only ever contain hosts that have a controlplane role.  So etcd only (maybe worker only too) nodes would not be in the map.  The second is after I fixed that, nginx is not defined for etcd only nodes.