### PR TITLE
when the hostname is uppercase, k8s add lowercase hostname to the kubernetes.io/hostname

### DIFF
--- a/k8s/node.go
+++ b/k8s/node.go
@@ -44,7 +44,7 @@ func GetNode(k8sClient *kubernetes.Clientset, nodeName string) (*v1.Node, error)
 		return nil, err
 	}
 	for _, node := range nodes.Items {
-		if node.Labels[HostnameLabel] == nodeName {
+		if strings.ToLower(node.Labels[HostnameLabel]) == strings.ToLower(nodeName) {
 			return &node, nil
 		}
 	}


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/12577
even I have the hostname Small2-Node1, but k8s will add small2-node1 for the label kubernetes.io/hostname. 
![image](https://user-images.githubusercontent.com/5936271/38808396-9ecc50c0-41b2-11e8-96e1-a61af6114d35.png)

I don't know whether we could use the lowercase to compare them, since the requestedHostname is dnsLabel type, so “Jabberwocky” and “jabberwocky” are both permissible domain name labels, but they are equivalent. If it not right, feel free to talk to me.
