### PR TITLE
Always try to pull

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -312,9 +312,6 @@ func (c *Cluster) PrePullK8sImages(ctx context.Context) error {
 	var errgrp errgroup.Group
 	hosts := hosts.GetUniqueHostList(c.EtcdHosts, c.ControlPlaneHosts, c.WorkerHosts)
 	for _, host := range hosts {
-		if !host.UpdateWorker {
-			continue
-		}
 		runHost := host
 		errgrp.Go(func() error {
 			return docker.UseLocalOrPull(ctx, runHost.DClient, runHost.Address, c.SystemImages.Kubernetes, "pre-deploy", c.PrivateRegistriesMap)


### PR DESCRIPTION
From what I can gather host.UpdateWorker is always false this point in the code.  This means we never actually pre-pull the images.  I removed this check as it doesn't seem bad to just check everyhost in the deployment always.  It should be fast.