### PR TITLE
WIP Use new rke-tools image

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -29,7 +29,10 @@ const (
 
 func GeneratePlan(ctx context.Context, rkeConfig *v3.RancherKubernetesEngineConfig, hostsInfoMap map[string]types.Info) (v3.RKEPlan, error) {
 	clusterPlan := v3.RKEPlan{}
-	myCluster, _ := ParseCluster(ctx, rkeConfig, "", "", nil, nil, nil)
+	myCluster, err := ParseCluster(ctx, rkeConfig, "", "", nil, nil, nil)
+	if err != nil {
+		return clusterPlan, err
+	}
 	// rkeConfig.Nodes are already unique. But they don't have role flags. So I will use the parsed cluster.Hosts to make use of the role flags.
 	uniqHosts := hosts.GetUniqueHostList(myCluster.EtcdHosts, myCluster.ControlPlaneHosts, myCluster.WorkerHosts)
 	for _, host := range uniqHosts {

--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -437,7 +437,7 @@ func (c *Cluster) BuildProxyProcess() v3.Process {
 	return v3.Process{
 		Name:          services.NginxProxyContainerName,
 		Env:           Env,
-		Args:          Env,
+		Args:          []string{"nginx-proxy"},
 		NetworkMode:   "host",
 		RestartPolicy: "always",
 		HealthCheck:   v3.HealthCheck{},

--- a/pki/deploy.go
+++ b/pki/deploy.go
@@ -46,6 +46,7 @@ func doRunDeployer(ctx context.Context, host *hosts.Host, containerEnv []string,
 	}
 	imageCfg := &container.Config{
 		Image: certDownloaderImage,
+		Cmd:   []string{"cert-deployer"},
 		Env:   containerEnv,
 	}
 	hostCfg := &container.HostConfig{


### PR DESCRIPTION
Instead of having rke-cert-deployer, rke-nginx-proxy, and alpine as supporting images, we just consolidate to one (rke-tools) as ever host is going to end up with all three images regardless.

This is missing the corresponding types change.