### PR TITLE
Add os-release to get proper OS info

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -332,6 +332,8 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, prefixPath string) v3.Pr
 		"/dev:/host/dev:rprivate",
 		fmt.Sprintf("%s:/var/log/containers:z", path.Join(prefixPath, "/var/log/containers")),
 		fmt.Sprintf("%s:/var/log/pods:z", path.Join(prefixPath, "/var/log/pods")),
+		"/usr:/host/usr:ro",
+		"/etc:/host/etc:ro",
 	}
 
 	for arg, value := range c.Services.Kubelet.ExtraArgs {


### PR DESCRIPTION
Fix implemented for https://github.com/rancher/rancher/issues/12776 was to remove Host Info but this would be nice to have.

Only caveat is that if `/etc/os-release` doesn't exist, it will break.