### PR TITLE
Add etcd env vars for etcdctl

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -589,10 +589,18 @@ func (c *Cluster) BuildEtcdProcess(host *hosts.Host, etcdHosts []*hosts.Host, pr
 	}
 	registryAuthConfig, _, _ := docker.GetImageRegistryConfig(c.Services.Etcd.Image, c.PrivateRegistriesMap)
 
+	Env := []string{}
+	Env = append(Env, "ETCDCTL_API=3")
+	Env = append(Env, fmt.Sprintf("ETCDCTL_ENDPOINT=https://%s:2379", listenAddress))
+	Env = append(Env, fmt.Sprintf("ETCDCTL_CACERT=%s", pki.GetCertPath(pki.CACertName)))
+	Env = append(Env, fmt.Sprintf("ETCDCTL_CERT=%s", pki.GetCertPath(nodeName)))
+	Env = append(Env, fmt.Sprintf("ETCDCTL_KEY=%s", pki.GetKeyPath(nodeName)))
+
 	return v3.Process{
 		Name:                    services.EtcdContainerName,
 		Args:                    args,
 		Binds:                   Binds,
+		Env:                     Env,
 		NetworkMode:             "host",
 		RestartPolicy:           "always",
 		Image:                   c.Services.Etcd.Image,


### PR DESCRIPTION
https://github.com/rancher/rke/issues/565

```
# docker exec etcd etcdctl member list
2018-05-02 11:50:12.691385 I | warning: ignoring ServerName for user-provided CA for backwards compatibility is deprecated
af4f1069717bae44, started, etcd-167.99.33.103, https://167.99.33.103:2380, https://167.99.33.103:2379,https://167.99.33.103:4001
c377226fab81158f, started, etcd-167.99.41.238, https://167.99.41.238:2380, https://167.99.41.238:2379,https://167.99.41.238:4001
e309dc3d5dbb513d, started, etcd-167.99.45.164, https://167.99.45.164:2380, https://167.99.45.164:2379,https://167.99.45.164:4001
```