### PR TITLE
Fix empty default calico cloud provider

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -156,14 +156,15 @@ func (c *Cluster) setClusterNetworkDefaults() {
 		c.Network.Options = make(map[string]string)
 	}
 	networkPluginConfigDefaultsMap := make(map[string]string)
+	// This is still needed because RKE doesn't use c.Network.*NetworkProvider, that's a rancher type
 	switch c.Network.Plugin {
-
 	case CalicoNetworkPlugin:
 		networkPluginConfigDefaultsMap = map[string]string{
 			CalicoCloudProvider: DefaultNetworkCloudProvider,
 		}
 	}
 	if c.Network.CalicoNetworkProvider != nil {
+		setDefaultIfEmpty(&c.Network.CalicoNetworkProvider.CloudProvider, DefaultNetworkCloudProvider)
 		networkPluginConfigDefaultsMap[CalicoCloudProvider] = c.Network.CalicoNetworkProvider.CloudProvider
 	}
 	if c.Network.FlannelNetworkProvider != nil {
@@ -175,5 +176,4 @@ func (c *Cluster) setClusterNetworkDefaults() {
 	for k, v := range networkPluginConfigDefaultsMap {
 		setDefaultIfEmptyMapValue(c.Network.Options, k, v)
 	}
-
 }


### PR DESCRIPTION
When using an empty network provider sent from rancher in `c.Network.CalicoNetworkProvider`, the default `none` is not set, instead, it gets overridden by the empty value. 
https://github.com/rancher/rancher/issues/13348