### PR TITLE
Fix override prefix path for ROS, B2D, and CoreOS

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -655,6 +655,8 @@ func BuildPortChecksFromPortList(host *hosts.Host, portList []string, proto stri
 func (c *Cluster) getPrefixPath(osType string) string {
 	var prefixPath string
 	switch {
+	case c.PrefixPath != "/":
+		prefixPath = c.PrefixPath
 	case strings.Contains(osType, B2DOS):
 		prefixPath = B2DPrefixPath
 	case strings.Contains(osType, ROS):


### PR DESCRIPTION
#484 