### PR TITLE
Added flag to ignore docker version

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -10,10 +10,14 @@ import (
 	"github.com/urfave/cli"
 )
 
-var sshCliOptions = []cli.Flag{
+var commonFlags = []cli.Flag{
 	cli.BoolFlag{
 		Name:  "ssh-agent-auth",
 		Usage: "Use SSH Agent Auth defined by SSH_AUTH_SOCK",
+	},
+	cli.BoolFlag{
+		Name:  "ignore-docker-version",
+		Usage: "Disable Docker version check",
 	},
 }
 
@@ -41,5 +45,10 @@ func setOptionsFromCLI(c *cli.Context, rkeConfig *v3.RancherKubernetesEngineConf
 	if c.Bool("ssh-agent-auth") {
 		rkeConfig.SSHAgentAuth = c.Bool("ssh-agent-auth")
 	}
+
+	if c.Bool("ignore-docker-version") {
+		rkeConfig.IgnoreDockerVersion = c.Bool("ignore-docker-version")
+	}
+
 	return rkeConfig, nil
 }

--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -26,7 +26,7 @@ func EtcdCommand() cli.Command {
 		},
 	}
 
-	backupRestoreFlags = append(backupRestoreFlags, sshCliOptions...)
+	backupRestoreFlags = append(backupRestoreFlags, commonFlags...)
 
 	return cli.Command{
 		Name:  "etcd",

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -35,7 +35,7 @@ func RemoveCommand() cli.Command {
 		},
 	}
 
-	removeFlags = append(removeFlags, sshCliOptions...)
+	removeFlags = append(removeFlags, commonFlags...)
 
 	return cli.Command{
 		Name:   "remove",

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -39,7 +39,7 @@ func UpCommand() cli.Command {
 		},
 	}
 
-	upFlags = append(upFlags, sshCliOptions...)
+	upFlags = append(upFlags, commonFlags...)
 
 	return cli.Command{
 		Name:   "up",
@@ -199,6 +199,9 @@ func clusterUpLocal(ctx *cli.Context) error {
 		}
 		rkeConfig.Nodes = []v3.RKEConfigNode{*cluster.GetLocalRKENodeConfig()}
 	}
+
+	rkeConfig.IgnoreDockerVersion = ctx.Bool("ignore-docker-version")
+
 	_, _, _, _, _, err = ClusterUp(context.Background(), rkeConfig, nil, hosts.LocalHealthcheckFactory, nil, true, "", false, false)
 	return err
 }


### PR DESCRIPTION
When using local, you don't need a config file, this makes it possible for

`rke up --local --ignore-docker-version`

and the corresponding

`rke remove --local --ignore-docker-version`