### PR TITLE
Improve port check error message

### DIFF
--- a/cluster/network.go
+++ b/cluster/network.go
@@ -447,7 +447,7 @@ func checkPlaneTCPPortsFromHost(ctx context.Context, host *hosts.Host, portList 
 	logrus.Debugf("[network] Length of containerLog is [%d] on host: %s", len(containerLog), host.Address)
 	if len(containerLog) > 0 {
 		portCheckLogs := strings.Join(strings.Split(strings.TrimSpace(containerLog), "\n"), ", ")
-		return fmt.Errorf("[network] Port check for ports: [%s] failed on host: [%s]", portCheckLogs, host.Address)
+		return fmt.Errorf("[network] Host [%s] is not able to connect to the following ports: [%s]. Please check network policies and firewall rules", host.Address, portCheckLogs)
 	}
 	return nil
 }


### PR DESCRIPTION
```
FATA[0011] [network] Host [x] is not able to connect to the following ports: [Y:2379, Y:2380, Z:2380, 2Z:2379]. Please check network policies and firewall rules
```

https://github.com/rancher/rke/issues/644