### PR TITLE
Add dind mode to rke

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rancher/rke/cluster"
+	"github.com/rancher/rke/dind"
 	"github.com/rancher/rke/hosts"
 	"github.com/rancher/rke/k8s"
 	"github.com/rancher/rke/log"
@@ -31,7 +32,11 @@ func RemoveCommand() cli.Command {
 		},
 		cli.BoolFlag{
 			Name:  "local",
-			Usage: "Deploy Kubernetes cluster locally",
+			Usage: "Remove Kubernetes cluster locally",
+		},
+		cli.BoolFlag{
+			Name:  "dind",
+			Usage: "Remove Kubernetes cluster deployed in dind mode",
 		},
 	}
 
@@ -94,6 +99,9 @@ func clusterRemoveFromCli(ctx *cli.Context) error {
 	if ctx.Bool("local") {
 		return clusterRemoveLocal(ctx)
 	}
+	if ctx.Bool("dind") {
+		return clusterRemoveDind(ctx)
+	}
 	clusterFilePath = filePath
 	rkeConfig, err := cluster.ParseConfig(clusterFile)
 	if err != nil {
@@ -129,4 +137,31 @@ func clusterRemoveLocal(ctx *cli.Context) error {
 	}
 
 	return ClusterRemove(context.Background(), rkeConfig, nil, nil, true, "")
+}
+
+func clusterRemoveDind(ctx *cli.Context) error {
+	clusterFile, filePath, err := resolveClusterFile(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to resolve cluster file: %v", err)
+	}
+
+	rkeConfig, err := cluster.ParseConfig(clusterFile)
+	if err != nil {
+		return fmt.Errorf("Failed to parse cluster file: %v", err)
+	}
+
+	rkeConfig, err = setOptionsFromCLI(ctx, rkeConfig)
+	if err != nil {
+		return err
+	}
+
+	for _, node := range rkeConfig.Nodes {
+		if err = dind.RmoveDindContainer(context.Background(), node.Address); err != nil {
+			return err
+		}
+	}
+	localKubeConfigPath := pki.GetLocalKubeConfig(filePath, "")
+	// remove the kube config file
+	pki.RemoveAdminConfig(context.Background(), localKubeConfigPath)
+	return err
 }

--- a/dind/dind.go
+++ b/dind/dind.go
@@ -1,0 +1,146 @@
+package dind
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/rancher/rke/docker"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	DINDImage           = "docker:17.03-dind"
+	DINDContainerPrefix = "rke-dind-"
+	DINDPlane           = "dind"
+	DINDNetwork         = "dind-network"
+	DINDSubnet          = "172.18.0.0/16"
+)
+
+func StartUpDindContainer(ctx context.Context, dindAddress, dindNetwork string) error {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
+	// its recommended to use host's storage driver
+	dockerInfo, err := cli.Info(ctx)
+	if err != nil {
+		return err
+	}
+	storageDriver := dockerInfo.Driver
+	// Get dind container name
+	containerName := DINDContainerPrefix + dindAddress
+	_, err = cli.ContainerInspect(ctx, containerName)
+	if err != nil {
+		if !client.IsErrNotFound(err) {
+			return err
+		}
+		if err := docker.UseLocalOrPull(ctx, cli, cli.DaemonHost(), DINDImage, DINDPlane, nil); err != nil {
+			return err
+		}
+		binds := []string{
+			fmt.Sprintf("/var/lib/kubelet-%s:/var/lib/kubelet:shared", containerName),
+			"/etc/resolv.conf:/etc/resolv.conf",
+		}
+		imageCfg := &container.Config{
+			Image: DINDImage,
+			Entrypoint: []string{
+				"sh",
+				"-c",
+				"mount --make-shared / && " +
+					"mount --make-shared /var/lib/docker && " +
+					"dockerd-entrypoint.sh --storage-driver=" + storageDriver,
+			},
+		}
+		hostCfg := &container.HostConfig{
+			Privileged: true,
+			Binds:      binds,
+		}
+		netCfg := &network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				dindNetwork: &network.EndpointSettings{
+					IPAMConfig: &network.EndpointIPAMConfig{
+						IPv4Address: dindAddress,
+					},
+				},
+			},
+		}
+		resp, err := cli.ContainerCreate(ctx, imageCfg, hostCfg, netCfg, containerName)
+		if err != nil {
+			return fmt.Errorf("Failed to create [%s] container on host [%s]: %v", containerName, cli.DaemonHost(), err)
+		}
+
+		if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+			return fmt.Errorf("Failed to start [%s] container on host [%s]: %v", containerName, cli.DaemonHost(), err)
+		}
+		logrus.Infof("[%s] Successfully started [%s] container on host [%s]", DINDPlane, containerName, cli.DaemonHost())
+		return nil
+	}
+	logrus.Infof("[%s] container [%s] is already running on host[%s]", DINDPlane, containerName, cli.DaemonHost())
+	return nil
+}
+
+func RmoveDindContainer(ctx context.Context, dindAddress string) error {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
+	containerName := DINDContainerPrefix + dindAddress
+	logrus.Infof("[%s] Removing dind container [%s] on host [%s]", DINDPlane, containerName, cli.DaemonHost())
+	_, err = cli.ContainerInspect(ctx, containerName)
+	if err != nil {
+		if !client.IsErrNotFound(err) {
+			return nil
+		}
+	}
+	if err := cli.ContainerRemove(ctx, containerName, types.ContainerRemoveOptions{
+		Force:         true,
+		RemoveVolumes: true}); err != nil {
+		return fmt.Errorf("Failed to remove dind container [%s] on host [%s]: %v", containerName, cli.DaemonHost(), err)
+	}
+	logrus.Infof("[%s] Successfully Removed dind container [%s] on host [%s]", DINDPlane, containerName, cli.DaemonHost())
+	return nil
+}
+
+func CreateDindNetwork(ctx context.Context, dindSubnet string) error {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
+	networkList, err := cli.NetworkList(ctx, types.NetworkListOptions{})
+	for _, net := range networkList {
+		if DINDNetwork == net.Name {
+			subnetFound := false
+			for _, netConfig := range net.IPAM.Config {
+				if netConfig.Subnet == dindSubnet {
+					subnetFound = true
+					break
+				}
+			}
+			if !subnetFound {
+				return fmt.Errorf("dind network [%s] exist but has different subnet than specified", DINDNetwork)
+			}
+			logrus.Infof("[%s] dind network [%s] with subnet [%s] already created", DINDPlane, DINDNetwork, dindSubnet)
+			return nil
+		}
+	}
+	logrus.Infof("[%s] creating dind network [%s] with subnet [%s]", DINDPlane, DINDNetwork, dindSubnet)
+	_, err = cli.NetworkCreate(ctx, DINDNetwork, types.NetworkCreate{
+		Driver: "bridge",
+		IPAM: &network.IPAM{
+			Config: []network.IPAMConfig{
+				network.IPAMConfig{
+					Subnet: dindSubnet,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	logrus.Infof("[%s] Successfully Created dind network [%s] with subnet [%s]", DINDPlane, DINDNetwork, dindSubnet)
+	return nil
+}

--- a/hosts/dialer.go
+++ b/hosts/dialer.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	DockerDialerTimeout = 30
+	DockerDialerTimeout = 50
 )
 
 type DialerFactory func(h *Host) (func(network, address string) (net.Conn, error), error)

--- a/hosts/dind.go
+++ b/hosts/dind.go
@@ -1,0 +1,41 @@
+package hosts
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+const (
+	DINDPort = "2375"
+)
+
+type dindDialer struct {
+	Address string
+	Port    string
+	Network string
+}
+
+func DindConnFactory(h *Host) (func(network, address string) (net.Conn, error), error) {
+	newDindDialer := &dindDialer{
+		Address: h.Address,
+		Port:    DINDPort,
+	}
+	return newDindDialer.Dial, nil
+}
+
+func DindHealthcheckConnFactory(h *Host) (func(network, address string) (net.Conn, error), error) {
+	newDindDialer := &dindDialer{
+		Address: h.Address,
+		Port:    strconv.Itoa(h.LocalConnPort),
+	}
+	return newDindDialer.Dial, nil
+}
+
+func (d *dindDialer) Dial(network, addr string) (net.Conn, error) {
+	conn, err := net.Dial(network, d.Address+":"+d.Port)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to dial dind address [%s]: %v", addr, err)
+	}
+	return conn, err
+}

--- a/services/healthcheck.go
+++ b/services/healthcheck.go
@@ -56,7 +56,7 @@ func runHealthcheck(ctx context.Context, host *hosts.Host, serviceName string, l
 	}
 	client, err := getHealthCheckHTTPClient(host, port, localConnDialerFactory, &x509Pair)
 	if err != nil {
-		return fmt.Errorf("Failed to initiate new HTTP client for service [%s] for host [%s]", serviceName, host.Address)
+		return fmt.Errorf("Failed to initiate new HTTP client for service [%s] for host [%s]: %v", serviceName, host.Address, err)
 	}
 	for retries := 0; retries < 10; retries++ {
 		if err = getHealthz(client, serviceName, host.Address, url); err != nil {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/14266

The dind mode will enable the user to deploy nodes as docker containers locally, each docker container has docker installed within, for example to create 3 node cluster in dind mode:
cluster.yml
```
nodes:
  - address: 172.18.0.9
    user: ubuntu
    role: [controlplane,worker,etcd]
  - address: 172.18.0.10
    user: ubuntu
    role: [controlplane,worker,etcd]
  - address: 172.18.0.11
    user: ubuntu
    role: [controlplane,worker,etcd]
```
and then:
```
rke up --dind
```
RKE will first create a network subnet called `dind-network` with subnet defaults to `172.18.0.0/16` and then deploy 3 nodes as docker containers and start kubernetes installation