### PR TITLE
fixes wrong value for soap-roundtrip-count in vsphere provider

### DIFF
--- a/templates/vsphere.go
+++ b/templates/vsphere.go
@@ -41,9 +41,7 @@ vm-name = "{{ .VsphereConfig.Global.VMName }}"
         {{- if ne $v.Datacenters "" }}
         datacenters = "{{ $v.Datacenters }}"
         {{- end }}
-        {{- if ne $v.Datacenters "" }}
-        soap-roundtrip-count = "{{ $v.Datacenters }}"
-        {{- end }}
+        soap-roundtrip-count = "{{ $v.RoundTripperCount }}"
 {{- end }}
 
 [Workspace]


### PR DESCRIPTION
The template for creating the cloud provider config file for vsphere uses a wrong value for soap-roundtrip-count in the VirtualCenter section.
This commit fixes that. It will set the value to 0 if not specified in RKE's cluster config. That should be ok as a value of 0 means "use the default" and the default is the value set in the global section.
