### PR TITLE
allow overlapping kubeconfigs by appending clusterName to user and context

### DIFF
--- a/pki/kubeconfig.go
+++ b/pki/kubeconfig.go
@@ -14,11 +14,11 @@ clusters:
 contexts:
 - context:
     cluster: "` + clusterName + `"
-    user: "` + componentName + `"
-  name: "Default"
-current-context: "Default"
+    user: "` + componentName + `-` + clusterName + `"
+  name: "` + clusterName + `"
+current-context: "` + clusterName + `"
 users:
-- name: "` + componentName + `"
+- name: "` + componentName + `-` + clusterName + `"
   user:
     client-certificate: ` + crtPath + `
     client-key: ` + keyPath + ``
@@ -36,11 +36,11 @@ clusters:
 contexts:
 - context:
     cluster: "` + clusterName + `"
-    user: "` + componentName + `"
-  name: "Default"
-current-context: "Default"
+    user: "` + componentName + `-` + clusterName + `"
+  name: "` + clusterName + `"
+current-context: "` + clusterName + `"
 users:
-- name: "` + componentName + `"
+- name: "` + componentName + `-` + clusterName + `"
   user:
     client-certificate-data: ` + base64.StdEncoding.EncodeToString([]byte(crt)) + `
     client-key-data: ` + base64.StdEncoding.EncodeToString([]byte(key)) + ``


### PR DESCRIPTION
We use RKE to build and maintain multiple clusters.  Generally, I set KUBECONFIG to include all the generated kube_config_cluster.yml files.  However, in all of them, after generation, the context is 'Default', and the user is 'kube-admin'.  This is problematic as kubectl cannot differentiate between clusters.

This patch assures that user and context are unique per cluster.