### PR TITLE
Add quotation mark for nginx-configuration

### DIFF
--- a/templates/nginx-ingress.go
+++ b/templates/nginx-ingress.go
@@ -15,7 +15,7 @@ metadata:
     app: ingress-nginx
 data:
 {{ range $k,$v := .Options }}
-  {{ $k }}: {{ $v }}
+  {{ $k }}: "{{ $v }}"
 {{ end }}
 ---
 kind: ConfigMap


### PR DESCRIPTION
Related issue https://github.com/rancher/rancher/issues/15044
Configmap resource data only support string data so
we should add quotation mark for each data item.