### PR TITLE
Fixed health check timing issue on slow platforms

### DIFF
--- a/services/healthcheck.go
+++ b/services/healthcheck.go
@@ -53,7 +53,7 @@ func runHealthcheck(ctx context.Context, host *hosts.Host, serviceName string, l
 	if err != nil {
 		return fmt.Errorf("Failed to initiate new HTTP client for service [%s] for host [%s]: %v", serviceName, host.Address, err)
 	}
-	for retries := 0; retries < 10; retries++ {
+	for retries := 0; retries < 50; retries++ {
 		if err = getHealthz(client, serviceName, host.Address, url); err != nil {
 			logrus.Debugf("[healthcheck] %v", err)
 			time.Sleep(5 * time.Second)


### PR DESCRIPTION
When using RKE to deploy Kubernetes clusters on Azure, I often run into the issue that the health checks fail, because some containers (e.g. kube-apiserver, kubelet) take too long for coming up.

Therefore I increased the maximum amount of retries from 10 to 50 and this solved the problem for me.

I think the best solution would be to make this configurable using the cluster.yml so that the default value can stick to 10.