### PR TITLE
Update ingress nginx template yaml

### DIFF
--- a/cluster/addons.go
+++ b/cluster/addons.go
@@ -355,7 +355,6 @@ func (c *Cluster) deployIngress(ctx context.Context) error {
 		Options:        c.Ingress.Options,
 		NodeSelector:   c.Ingress.NodeSelector,
 		ExtraArgs:      c.Ingress.ExtraArgs,
-		AlpineImage:    c.SystemImages.Alpine,
 		IngressImage:   c.SystemImages.Ingress,
 		IngressBackend: c.SystemImages.IngressBackend,
 	}

--- a/templates/nginx-ingress.go
+++ b/templates/nginx-ingress.go
@@ -193,16 +193,6 @@ spec:
       {{if eq .RBACConfig "rbac"}}
       serviceAccountName: nginx-ingress-serviceaccount
       {{ end }}
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range="1024 65535"
-        image: {{.AlpineImage}}
-        imagePullPolicy: IfNotPresent
-        name: sysctl
-        securityContext:
-          privileged: true
       containers:
         - name: nginx-ingress-controller
           image: {{.IngressImage}}
@@ -213,6 +203,13 @@ spec:
             - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
             - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
             - --annotations-prefix=nginx.ingress.kubernetes.io
+          securityContext:
+            capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+            runAsUser: 33
           {{ range $k, $v := .ExtraArgs }}
             - --{{ $k }}{{if ne $v "" }}={{ $v }}{{end}}
           {{ end }}


### PR DESCRIPTION
https://github.com/rancher/rke/issues/893

the PR updates the yaml template to follow the official ingress nginx deployment:
https://github.com/kubernetes/ingress-nginx/blob/nginx-0.16.2/deploy/mandatory.yaml

described in the official documentation:
https://kubernetes.github.io/ingress-nginx/deploy/