### PR TITLE
Publish archives in release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,8 +33,8 @@ pipeline:
     image: plugins/github-release
     prerelease: true
     files:
-     - bin/*
      - build/bin/rke_*
+     - dist/artifacts/${DRONE_TAG}/*
     checksum:
      - sha256
     secrets: [github_token]
@@ -47,8 +47,8 @@ pipeline:
   github_binary_release:
     image: plugins/github-release
     files:
-     - bin/*
      - build/bin/rke_*
+     - dist/artifacts/${DRONE_TAG}/*
     checksum:
      - sha256
     secrets: [github_token]

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,7 +5,7 @@ ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
 RUN apt-get update && \
-    apt-get install -y gcc ca-certificates git wget curl vim less file kmod iptables && \
+    apt-get install -y gcc ca-certificates git wget curl vim less file kmod iptables xz-utils zip && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \

--- a/scripts/package
+++ b/scripts/package
@@ -3,17 +3,76 @@ set -e
 
 source $(dirname $0)/version
 
+cd $(dirname $0)/..
+
+DIST=$(pwd)/dist/artifacts
+
+mkdir -p $DIST/${VERSION} $DIST/latest
+
+for i in build/bin/*; do
+    if [ ! -e $i ]; then
+        continue
+    fi
+
+    BASE=build/archive
+    DIR=${BASE}/rke-${VERSION}
+
+    rm -rf $BASE
+    mkdir -p $BASE $DIR
+
+    EXT=
+    if [[ $i =~ .*windows.* ]]; then
+        EXT=.exe
+    fi
+
+    cp $i ${DIR}/rke${EXT}
+
+    arch=$(echo $i | cut -f2 -d_)
+    mkdir -p $DIST/${VERSION}/binaries/$arch
+    mkdir -p $DIST/latest/binaries/$arch
+    cp $i $DIST/${VERSION}/binaries/$arch/rke${EXT}
+    if [ -z "${EXT}" ]; then
+        gzip -c $i > $DIST/${VERSION}/binaries/$arch/rke.gz
+        xz -c $i > $DIST/${VERSION}/binaries/$arch/rke.xz
+    fi
+
+    rm -rf $DIST/latest/binaries/$arch
+    mkdir -p $DIST/latest/binaries
+    cp -rf $DIST/${VERSION}/binaries/$arch $DIST/latest/binaries
+
+    (
+        cd $BASE
+        NAME=$(basename $i | sed 's/_/-/g')
+        if [ -z "$EXT" ]; then
+            tar cvzf $DIST/${VERSION}/${NAME}-${VERSION}.tar.gz .
+            cp $DIST/${VERSION}/${NAME}-${VERSION}.tar.gz $DIST/latest/${NAME}.tar.gz
+
+            tar cvJf $DIST/${VERSION}/${NAME}-${VERSION}.tar.xz .
+            cp $DIST/${VERSION}/${NAME}-${VERSION}.tar.xz $DIST/latest/${NAME}.tar.xz
+        else
+            NAME=$(echo $NAME | sed 's/'${EXT}'//g')
+            zip -r $DIST/${VERSION}/${NAME}-${VERSION}.zip *
+            cp $DIST/${VERSION}/${NAME}-${VERSION}.zip $DIST/latest/${NAME}.zip
+        fi
+    )
+done
+
+
 ARCH=${ARCH:-"amd64"}
 SUFFIX=""
 [ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 
-cd $(dirname $0)/../package
+cd package
 
 TAG=${TAG:-${VERSION}${SUFFIX}}
-REPO=${REPO:-rancher}
+REPO=${REPO:-rke}
 
 if echo $TAG | grep -q dirty; then
     TAG=dev
+fi
+
+if [ -n "$DRONE_TAG" ]; then
+    TAG=$DRONE_TAG
 fi
 
 cp ../bin/rke .


### PR DESCRIPTION
* Synced the build script with `rancher/cli`
* Removed publishing `./bin/rke`

Probably best to merge this after releasing v0.1.10, then we can release v0.1.11 with binaries and archives and make a note that it will be only archives in v0.1.12.

@cloudnautique to check