### PR TITLE
Added info in log messages, more consistency in log messages

### DIFF
--- a/cluster/addons.go
+++ b/cluster/addons.go
@@ -105,7 +105,7 @@ func (c *Cluster) deployAddonsInclude(ctx context.Context) error {
 	log.Infof(ctx, "[addons] Checking for included user addons")
 
 	if len(c.AddonsInclude) == 0 {
-		log.Infof(ctx, "[addons] No included addon paths or urls..")
+		log.Infof(ctx, "[addons] No included addon paths or urls")
 		return nil
 	}
 	for _, addon := range c.AddonsInclude {
@@ -198,7 +198,7 @@ func (c *Cluster) deployKubeDNS(ctx context.Context) error {
 	if err := c.doAddonDeploy(ctx, kubeDNSYaml, KubeDNSAddonResourceName, false); err != nil {
 		return err
 	}
-	log.Infof(ctx, "[addons] KubeDNS deployed successfully..")
+	log.Infof(ctx, "[addons] KubeDNS deployed successfully")
 	return nil
 }
 
@@ -216,7 +216,7 @@ func (c *Cluster) deployMetricServer(ctx context.Context) error {
 	if err := c.doAddonDeploy(ctx, metricsYaml, MetricsServerAddonResourceName, false); err != nil {
 		return err
 	}
-	log.Infof(ctx, "[addons] KubeDNS deployed successfully..")
+	log.Infof(ctx, "[addons] Metrics Server deployed successfully")
 	return nil
 }
 
@@ -241,7 +241,7 @@ func (c *Cluster) doAddonDeploy(ctx context.Context, addonYaml, resourceName str
 		return &addonError{fmt.Sprintf("Failed to save addon ConfigMap: %v", err), isCritical}
 	}
 
-	log.Infof(ctx, "[addons] Executing deploy job..")
+	log.Infof(ctx, "[addons] Executing deploy job %s", resourceName)
 	k8sClient, err := k8s.NewClient(c.LocalKubeConfigPath, c.K8sWrapTransport)
 	if err != nil {
 		return &addonError{fmt.Sprintf("%v", err), isCritical}
@@ -296,7 +296,7 @@ func (c *Cluster) doAddonDelete(ctx context.Context, resourceName string, isCrit
 }
 
 func (c *Cluster) StoreAddonConfigMap(ctx context.Context, addonYaml string, addonName string) (bool, error) {
-	log.Infof(ctx, "[addons] Saving addon ConfigMap to Kubernetes")
+	log.Infof(ctx, "[addons] Saving ConfigMap for addon %s to Kubernetes", addonName)
 	updated := false
 	kubeClient, err := k8s.NewClient(c.LocalKubeConfigPath, c.K8sWrapTransport)
 	if err != nil {
@@ -311,7 +311,7 @@ func (c *Cluster) StoreAddonConfigMap(ctx context.Context, addonYaml string, add
 				time.Sleep(time.Second * 5)
 				continue
 			}
-			log.Infof(ctx, "[addons] Successfully Saved addon to Kubernetes ConfigMap: %s", addonName)
+			log.Infof(ctx, "[addons] Successfully saved ConfigMap for addon %s to Kubernetes", addonName)
 			timeout <- true
 			break
 		}
@@ -366,6 +366,6 @@ func (c *Cluster) deployIngress(ctx context.Context) error {
 	if err := c.doAddonDeploy(ctx, ingressYaml, IngressAddonResourceName, false); err != nil {
 		return err
 	}
-	log.Infof(ctx, "[ingress] ingress controller %s is successfully deployed", c.Ingress.Provider)
+	log.Infof(ctx, "[ingress] ingress controller %s deployed successfully", c.Ingress.Provider)
 	return nil
 }

--- a/k8s/job.go
+++ b/k8s/job.go
@@ -75,13 +75,13 @@ func ensureJobCompleted(k8sClient *kubernetes.Clientset, j interface{}) error {
 
 	jobStatus, err := GetK8sJobStatus(k8sClient, job.Name, job.Namespace)
 	if err != nil {
-		return fmt.Errorf("Failed to get job complete status: %v", err)
+		return fmt.Errorf("Failed to get job complete status for job %s in namespace %s: %v", job.Name, job.Namespace, err)
 	}
 	if jobStatus.Completed {
-		logrus.Debugf("[k8s] Job %s completed successfully..", job.Name)
+		logrus.Debugf("[k8s] Job %s in namespace %s completed successfully", job.Name, job.Namespace)
 		return nil
 	}
-	return fmt.Errorf("Failed to get job complete status: %v", err)
+	return fmt.Errorf("Failed to get job complete status for job %s in namespace %s", job.Name, job.Namespace)
 }
 
 func ensureJobDeleted(k8sClient *kubernetes.Clientset, j interface{}) error {


### PR DESCRIPTION
* Consistency in log messages (removed `..`)
* Corrected Metrics Server deploy message (which said KubeDNS)
* Added more info on job log messages
* Removed the reference to `err` in last which caused:

```
Failed to get job complete status: <nil>
```