### PR TITLE
Add support for SSH certificate authentication

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -28,4 +28,4 @@ github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0e
 github.com/mattn/go-colorable            efa589957cd060542a26d2dd7832fd6a6c6c3ade
 github.com/mattn/go-isatty               6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 github.com/rancher/norman                0557aa4ff31a3a0f007dcb1b684894f23cda390c
-github.com/rancher/types                 1e6b3e4c5ff0169e35c48e7517396d62f56957a8
+github.com/rancher/types                 829746ec5e70eadfb8fc226de10d6d89d26501b2 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
@@ -26,7 +26,8 @@ type GlobalDNSSpec struct {
 }
 
 type GlobalDNSStatus struct {
-	Endpoints []string `json:"endpoints,omitempty"`
+	Endpoints        []string            `json:"endpoints,omitempty"`
+	ClusterEndpoints map[string][]string `json:"clusterEndpoints,omitempty"`
 }
 
 type GlobalDNSProvider struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/machine_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/machine_types.go
@@ -168,8 +168,10 @@ type CustomConfig struct {
 	// Optional - Docker socket on the node that will be used in tunneling
 	DockerSocket string `yaml:"docker_socket" json:"dockerSocket,omitempty"`
 	// SSH Private Key
-	SSHKey string            `yaml:"ssh_key" json:"sshKey,omitempty" norman:"type=password"`
-	Label  map[string]string `yaml:"label" json:"label,omitempty"`
+	SSHKey string `yaml:"ssh_key" json:"sshKey,omitempty" norman:"type=password"`
+	// SSH Certificate
+	SSHCert string            `yaml:"ssh_cert" json:"sshCert,omitempty"`
+	Label   map[string]string `yaml:"label" json:"label,omitempty"`
 }
 
 type NodeSpec struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
@@ -17,6 +17,8 @@ type RancherKubernetesEngineConfig struct {
 	SystemImages RKESystemImages `yaml:"system_images" json:"systemImages,omitempty"`
 	// SSH Private Key Path
 	SSHKeyPath string `yaml:"ssh_key_path" json:"sshKeyPath,omitempty"`
+	// SSH Certificate Path
+	SSHCertPath string `yaml:"ssh_cert_path" json:"sshCertPath,omitempty"`
 	// SSH Agent Auth enable
 	SSHAgentAuth bool `yaml:"ssh_agent_auth" json:"sshAgentAuth"`
 	// Authorization mode configuration used in the cluster
@@ -62,6 +64,10 @@ type BastionHost struct {
 	SSHKey string `yaml:"ssh_key" json:"sshKey,omitempty" norman:"type=password"`
 	// SSH Private Key Path
 	SSHKeyPath string `yaml:"ssh_key_path" json:"sshKeyPath,omitempty"`
+	// SSH Certificate
+	SSHCert string `yaml:"ssh_cert" json:"sshCert,omitempty"`
+	// SSH Certificate Path
+	SSHCertPath string `yaml:"ssh_cert_path" json:"sshCertPath,omitempty"`
 }
 
 type PrivateRegistry struct {
@@ -155,6 +161,10 @@ type RKEConfigNode struct {
 	SSHKey string `yaml:"ssh_key" json:"sshKey,omitempty" norman:"type=password"`
 	// SSH Private Key Path
 	SSHKeyPath string `yaml:"ssh_key_path" json:"sshKeyPath,omitempty"`
+	// SSH Certificate
+	SSHCert string `yaml:"ssh_cert" json:"sshCert,omitempty"`
+	// SSH Certificate Path
+	SSHCertPath string `yaml:"ssh_cert_path" json:"sshCertPath,omitempty"`
 	// Node Labels
 	Labels map[string]string `yaml:"labels" json:"labels,omitempty"`
 }

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -2906,6 +2906,21 @@ func (in *GlobalDNSStatus) DeepCopyInto(out *GlobalDNSStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ClusterEndpoints != nil {
+		in, out := &in.ClusterEndpoints, &out.ClusterEndpoints
+		*out = make(map[string][]string, len(*in))
+		for key, val := range *in {
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
+		}
+	}
 	return
 }
 

--- a/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
+++ b/vendor/github.com/rancher/types/apis/project.cattle.io/v3/app_types.go
@@ -29,9 +29,10 @@ type AppSpec struct {
 }
 
 var (
-	AppConditionInstalled condition.Cond = "Installed"
-	AppConditionMigrated  condition.Cond = "Migrated"
-	AppConditionDeployed  condition.Cond = "Deployed"
+	AppConditionInstalled    condition.Cond = "Installed"
+	AppConditionMigrated     condition.Cond = "Migrated"
+	AppConditionDeployed     condition.Cond = "Deployed"
+	AppConditionForceUpgrade condition.Cond = "ForceUpgrade"
 )
 
 type AppStatus struct {
@@ -75,10 +76,12 @@ type AppRevisionStatus struct {
 }
 
 type AppUpgradeConfig struct {
-	ExternalID string            `json:"externalId,omitempty"`
-	Answers    map[string]string `json:"answers,omitempty"`
+	ExternalID   string            `json:"externalId,omitempty"`
+	Answers      map[string]string `json:"answers,omitempty"`
+	ForceUpgrade bool              `json:"forceUpgrade,omitempty"`
 }
 
 type RollbackRevision struct {
 	RevisionName string `json:"revisionName,omitempty" norman:"type=reference[/v3/project/schemas/apprevision]"`
+	ForceUpgrade bool   `json:"forceUpgrade,omitempty"`
 }


### PR DESCRIPTION
## What does this do
Implements https://github.com/rancher/rke/issues/1002

Add support for SSH certificates when using RKE. 

Pending `types` PR: https://github.com/rancher/types/pull/583

RKE fork that relies on changes: 
https://github.com/bernard-wagner/rke/tree/ssh-cert

For more background:

https://man.openbsd.org/ssh-keygen.1#CERTIFICATES
https://man.openbsd.org/sshd_config#TrustedUserCAKeys

## How it was tested

### Created CA

```
$ ssh-keygen -t rsa -b 4096 -f demo-ca -q -P ""
$ cat demo-ca.pub
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXoifoWpZ/SC5bzOSmBmCRJMM4lF2....
```

### Provisioned CoreOS Node with following cloud-config:

```
storage:
  files:
    - filesystem: root
      user: 
        name: root
      group: 
        name: root
      path: /etc/ssh/ssh_trusted_user_ca_keys
      mode: 0644
      contents: 
        inline: |
          ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXoifoWpZ/SC5bzOSmBmCRJMM4lF2....
    - filesystem: root
      path: /etc/ssh/sshd_config
      contents: 
        inline: |
          UsePrivilegeSeparation sandbox
          Subsystem sftp internal-sftp
          UseDNS no

          PermitRootLogin no
          AllowUsers core
          AuthenticationMethods publickey        
          TrustedUserCAKeys /etc/ssh/ssh_trusted_user_ca_keys
```

### Created New KeyPair 
```
$ ssh-keygen -f test-key -q -P ""
```

### Signed KeyPair

```
$ ssh-keygen -s demo-ca -I TEST -n core -V +2h test-key.pub
```

### Init Cluster (cluster.yml)
```
nodes:
    - address: 192.168.56.101
      port: 22
      user: core
      role:
        - controlplane
        - etcd
        - worker
      ssh_key_path: ./test-key
      ssh_cert_path: ./test-key-cert.pub
    
ignore_docker_version: true    
```
### Node with inline certificate:

```
nodes:
    - address: 192.168.56.101
      port: 22
      user: core
      role:
        - controlplane
        - etcd
        - worker
      ssh_key_path: ./test-key
      ssh_cert: |-
        ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3Bl....
         
ignore_docker_version: true    
```
### Bastion Test with authorized_keys (cluster.yml)

Reinitialized host and added another with a preconfigured authorized_keys file:
```
nodes:
  - address: 192.168.56.102
    port: 22
    user: core
    role:
      - controlplane
      - etcd
      - worker
    ssh_key: |-
      -----BEGIN RSA PRIVATE KEY-----
      .....
      -----END RSA PRIVATE KEY-----

bastion_host:
    address: 192.168.56.101
    user: core
    port: 22
    ssh_key_path: ./test-key
    ssh_cert_path: ./test-key-cert.pub

ignore_docker_version: true    
```


### Bastion Test with Certificates (cluster.yml)

Reinitialized host and added another with a preconfigured authorized_keys file:
```
nodes:
  - address: 192.168.56.102
    port: 22
    user: core
    role:
      - controlplane
      - etcd
      - worker
    ssh_key_path: ./test-key
    ssh_cert_path: ./test-key-cert.pub

bastion_host:
    address: 192.168.56.101
    user: core
    port: 22
    ssh_key_path: ./test-key
    ssh_cert_path: ./test-key-cert.pub

ignore_docker_version: true    
```
