### PR TITLE
WIP Add functionality to upload etcd snapshots to S3

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -12,7 +12,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN wget -O - https://storage.googleapis.com/golang/go1.8.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+    go get github.com/rancher/trash && go get golang.org/x/lint/golint 
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \

--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -11,9 +11,9 @@ import (
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 )
 
-func (c *Cluster) SnapshotEtcd(ctx context.Context, snapshotName string) error {
+func (c *Cluster) SnapshotEtcd(ctx context.Context, snapshotName, s3bucket, s3credsfile, s3configfile string, s3 bool) error {
 	for _, host := range c.EtcdHosts {
-		if err := services.RunEtcdSnapshotSave(ctx, host, c.PrivateRegistriesMap, c.SystemImages.Alpine, c.Services.Etcd.Creation, c.Services.Etcd.Retention, snapshotName, true); err != nil {
+		if err := services.RunEtcdSnapshotSave(ctx, host, c.PrivateRegistriesMap, c.SystemImages.Alpine, c.Services.Etcd.Creation, c.Services.Etcd.Retention, snapshotName, s3bucket, s3credsfile, s3configfile, s3, true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Hi there,

This PR adds the functionality to RKE to upload etcd snapshots directly to AWS S3.
Feature request this targets: https://github.com/rancher/rke/issues/616
It adds the following new flags:

-  `--s3`: feature toggle
- `--s3-bucket`: where to upload it (can be `<bucket>/<sub-path>`)
- `--s3-credentials FILE`: path to AWS credentials file
- `--s3-config FILE`: path to AWS config file (for region)

By default, the credentials + config from `~/.aws/credentials` + `~/.aws/config` will be used respectively.

Link to related PR in rke-tools: https://github.com/rancher/rke-tools/pull/27