### PR TITLE
Fix flannel startup in new cluster

### DIFF
--- a/templates/flannel.go
+++ b/templates/flannel.go
@@ -170,6 +170,9 @@ spec:
         operator: Exists
         effect: NoExecute
       {{- end }}
+      - key: node.kubernetes.io/not-ready
+        effect: NoSchedule
+        operator: Exists
       volumes:
         - name: run
           hostPath:


### PR DESCRIPTION
In a new cluster the nodes will be NotReady until the network cni plugin is configured. Since the flannel daemonset is responsible for setting this up it needs to be able to schedule on nodes that are NotReady

Signed-off-by: Joshua Benjamin <joshuabnjmn@gmail.com>