### PR TITLE
Allow creating Kubernetes clusters without a cluster network

### DIFF
--- a/cluster/network.go
+++ b/cluster/network.go
@@ -39,6 +39,8 @@ const (
 	ProtocolTCP = "TCP"
 	ProtocolUDP = "UDP"
 
+	NoNetworkPlugin = "none"
+
 	FlannelNetworkPlugin = "flannel"
 	FlannelIface         = "flannel_iface"
 	FlannelBackendType   = "flannel_backend_type"
@@ -120,6 +122,9 @@ func (c *Cluster) deployNetworkPlugin(ctx context.Context) error {
 		return c.doCanalDeploy(ctx)
 	case WeaveNetworkPlugin:
 		return c.doWeaveDeploy(ctx)
+	case NoNetworkPlugin:
+		log.Infof(ctx, "[network] Not deploying a cluster network, expecting custom CNI")
+		return nil
 	default:
 		return fmt.Errorf("[network] Unsupported network plugin: %s", c.Network.Plugin)
 	}

--- a/cluster/validation.go
+++ b/cluster/validation.go
@@ -46,7 +46,7 @@ func validateAuthOptions(c *Cluster) error {
 }
 
 func validateNetworkOptions(c *Cluster) error {
-	if c.Network.Plugin != FlannelNetworkPlugin && c.Network.Plugin != CalicoNetworkPlugin && c.Network.Plugin != CanalNetworkPlugin && c.Network.Plugin != WeaveNetworkPlugin {
+	if c.Network.Plugin != NoNetworkPlugin && c.Network.Plugin != FlannelNetworkPlugin && c.Network.Plugin != CalicoNetworkPlugin && c.Network.Plugin != CanalNetworkPlugin && c.Network.Plugin != WeaveNetworkPlugin {
 		return fmt.Errorf("Network plugin [%s] is not supported", c.Network.Plugin)
 	}
 	return nil


### PR DESCRIPTION
Create an RKE config file like:
```
nodes:
    - address: 192.168.100.129
      user: docker
      role:
        - controlplane
        - etcd
    - address: 192.168.100.130
      user: docker
      role:
        - worker
    - address: 192.168.100.131
      user: docker
      role:
        - worker
network:
  plugin: none
```

https://github.com/rancher/rke/issues/873