### PR TITLE
CIS Benchmark recommended options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /trash.lock
 kube_config*
 /rke
+.vscode

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -37,6 +37,7 @@ type Cluster struct {
 	ClusterDomain                    string
 	ClusterCIDR                      string
 	ClusterDNSServer                 string
+	DinD                             bool
 	DockerDialerFactory              hosts.DialerFactory
 	EtcdHosts                        []*hosts.Host
 	EtcdReadyHosts                   []*hosts.Host
@@ -150,6 +151,7 @@ func InitClusterObject(ctx context.Context, rkeConfig *v3.RancherKubernetesEngin
 		RancherKubernetesEngineConfig: *rkeConfig,
 		ConfigPath:                    flags.ClusterFilePath,
 		ConfigDir:                     flags.ConfigDir,
+		DinD:                          flags.DinD,
 		StateFilePath:                 GetStateFilePath(flags.ClusterFilePath, flags.ConfigDir),
 		PrivateRegistriesMap:          make(map[string]v3.PrivateRegistry),
 	}

--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -54,6 +54,7 @@ const (
 type ExternalFlags struct {
 	ConfigDir        string
 	ClusterFilePath  string
+	DinD             bool
 	DisablePortCheck bool
 	Local            bool
 	UpdateOnly       bool

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -315,6 +315,7 @@ func clusterUpDind(ctx *cli.Context) error {
 	dialers := hosts.GetDialerOptions(hosts.DindConnFactory, hosts.DindHealthcheckConnFactory, nil)
 	// setting up flags
 	flags := cluster.GetExternalFlags(false, false, disablePortCheck, "", filePath)
+	flags.DinD = true
 
 	if ctx.Bool("init") {
 		return ClusterInit(context.Background(), rkeConfig, dialers, flags)

--- a/scripts/ci
+++ b/scripts/ci
@@ -6,4 +6,5 @@ cd $(dirname $0)
 ./build
 ./test
 ./validate
+./integration
 ./package

--- a/scripts/integration
+++ b/scripts/integration
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+function cleanup {
+    echo ""
+    echo "---- Clean Up RKE ----"
+    for i in ./bin/cluster-*.yml; do
+        ./bin/rke remove --dind --force --config $i 2>&1 >/dev/null
+    done
+    rm -f ./bin/*.rkestate ./bin/*.yml
+}
+trap cleanup TERM EXIT
+
+pids=""
+tail_pids=""
+RESULT="0"
+declare -A versions_to_test
+declare -A pids_to_version
+declare -A pids_results
+
+echo "INFO - Running $0"
+source $(dirname $0)/version
+
+cd $(dirname $0)/..
+
+
+# Get latest version from rke
+all_versions=$(./bin/rke config --all --system-images 2>&1 | grep "Generating images list for version" | sed -E 's/.*\[(.*)\].*/\1/' | sort -V)
+
+# Get the latest of the major.minor versions.
+for ver in $all_versions; do
+    # clean up list. Remove blanks
+    ver=$(echo $ver | xargs echo -n)
+    if [ -z "$ver" ]; then
+        continue
+    fi
+
+    #split value on .
+    split=($(echo $ver | tr '.' '\n'))
+    major_ver="${split[0]}.${split[1]}"
+    versions_to_test["${major_ver}"]="${ver}"
+done
+
+for ver in "${!versions_to_test[@]}"; do
+    echo "testing ${versions_to_test["${ver}"]}"
+
+    # Create cluster yaml with random node names
+    node=$(cat /dev/urandom | tr -dc a-z | head -c${1:-8})
+    cat << EOF > "./bin/cluster-${versions_to_test["${ver}"]}.yml"
+kubernetes_version: ${versions_to_test["${ver}"]}
+nodes:
+- address: rke-node-${node}
+  role: [etcd, controlplane, worker]
+  user: ubuntu
+EOF
+
+    # Run rke - output to logs and track results.
+    ./bin/rke up --dind --config "./bin/cluster-${versions_to_test["${ver}"]}.yml" 2>&1 >"./bin/cluster-${versions_to_test["${ver}"]}.log" &
+    pids="$pids $!"
+    pid_to_version["$!"]="${versions_to_test["${ver}"]}"
+
+    # Tail logs.
+    sleep 1
+    tail -f "./bin/cluster-${versions_to_test["${ver}"]}.log" &
+    tail_pids="$tail_pids $!"
+done
+
+# Wait for rke to finish
+for pid in $pids; do
+    wait $pid
+    pid_results["${pid}"]="$?"
+done
+
+# Stop tailing the logs
+for pid in $tail_pids; do
+    kill $pid 2>&1 >/dev/null
+done
+
+echo ""
+echo "---- TEST RESULTS ----"
+for pid in "${!pid_results[@]}"; do
+    if [ "${pid_results["${pid}"]}" == "0" ]; then
+        echo "[PASS] ${pid_to_version["${pid}"]}"
+    else
+        echo "[FAIL] ${pid_to_version["${pid}"]}"
+        RESULT="1"
+    fi
+done
+
+if [ "$RESULT" == "1" ]; then
+    exit 1
+fi

--- a/util/util.go
+++ b/util/util.go
@@ -37,3 +37,17 @@ func ErrList(e []error) error {
 	}
 	return nil
 }
+
+// UniqueStringSlice - Input slice, retrun slice with unique elements. Will not maintain order.
+func UniqueStringSlice(elements []string) []string {
+	encountered := map[string]bool{}
+	result := []string{}
+
+	for v := range elements {
+		if !encountered[elements[v]] {
+			encountered[elements[v]] = true
+			result = append(result, elements[v])
+		}
+	}
+	return result
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,4 +28,4 @@ github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0e
 github.com/mattn/go-colorable            efa589957cd060542a26d2dd7832fd6a6c6c3ade
 github.com/mattn/go-isatty               6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 github.com/rancher/norman                0557aa4ff31a3a0f007dcb1b684894f23cda390c
-github.com/rancher/types                 4bbd2dbd8de1cc906863467777afa2003c81b5cf
+github.com/rancher/types                 a6037e6ab730d9c660f0dad7f95a3880dcfe773d

--- a/vendor/github.com/rancher/types/.gitignore
+++ b/vendor/github.com/rancher/types/.gitignore
@@ -7,3 +7,4 @@
 /trash.lock
 /types
 *trash.lock
+.vscode/

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
@@ -35,7 +35,6 @@ var (
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"cadvisor-port":     "",
 			},
 		},
 		"v1.11": {
@@ -45,6 +44,7 @@ var (
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"cadvisor-port":     "0",
 			},
 		},
 		"v1.10": {
@@ -55,12 +55,16 @@ var (
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"cadvisor-port":     "0",
 			},
 		},
 		"v1.9": {
 			KubeAPI: map[string]string{
 				"endpoint-reconciler-type": "lease",
 				"admission-control":        "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
+			},
+			Kubelet: map[string]string{
+				"cadvisor-port": "0",
 			},
 		},
 	}
@@ -709,10 +713,10 @@ var (
 		"v1.12.4-rancher1-1": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.2.24"),
 			Kubernetes:                m("rancher/hyperkube:v1.12.4-rancher1"),
-			Alpine:                    m("rancher/rke-tools:v0.1.18"),
-			NginxProxy:                m("rancher/rke-tools:v0.1.18"),
-			CertDownloader:            m("rancher/rke-tools:v0.1.18"),
-			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.18"),
+			Alpine:                    m("rancher/rke-tools:v0.1.20"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.20"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.20"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.20"),
 			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.13"),
 			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.13"),
 			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.13"),

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
@@ -200,6 +200,8 @@ type KubeAPIService struct {
 	ServiceNodePortRange string `yaml:"service_node_port_range" json:"serviceNodePortRange,omitempty" norman:"default=30000-32767"`
 	// Enabled/Disable PodSecurityPolicy
 	PodSecurityPolicy bool `yaml:"pod_security_policy" json:"podSecurityPolicy,omitempty"`
+	// Enable/Disable AlwaysPullImages admissions plugin
+	AlwaysPullImages bool `yaml:"always_pull_images" json:"always_pull_images,omitempty"`
 }
 
 type KubeControllerService struct {


### PR DESCRIPTION
First in a set of recommended options for CIS Kubernetes Benchmark guidelines.

Command Options: (sorry reordered the lists alphabetically to make it easier to find options)
kubelet:
* streaming-connection-idle-timeout: "30m"
* make-iptables-util-chains: "true"
* event-qps: "0"

kubeapi:
* anonymous-auth: "false"
* unset insecure-bind-address
* profiling: "false"
* repair-malformed-updates: false
* service-account-lookup: true
* enable-admission-plugins: ...NodeRestriction...

kube-scheduler:
* profiling: "false"
* address: "127.0.0.1" ("0.0.0.0" when DinD)

kube-controller-manager:
* terminated-pod-gc-threshold: "1000"
* profiling: "false"
* address: "127.0.0.1" ("0.0.0.0" when DinD)

kube-proxy:
* healthz-bind-address: "127.0.0.1" ("0.0.0.0" when DinD)

---

Moved cadvisor-port out of global default into k8s_defaults for various versions. 

---

Modified admission-plugins to work as a []string and then write out to a comma separated string for easier add/remove admissions plugins.

---

Created `scripts/integration` test. Grabs list of the latest "major.minor" k8s versions from rke and creates a DinD instance for each version (1.8 -> 1.12). If build succeeds and rke exits 0, tests pass.  If not it fails. Either way cleans up after its self when tests are done.    

This test does do all 5 instances simultaneously, so its resource heavy (especially network since it has to pull all the hyperkube images).  I think its valuable, but if we don't want it in the normal "ci" set I can pull it out.

---

Fixed typo `kubeletDcokerConfig`. It was bugging me :)

