### PR TITLE
CIS Benchmark - Admission Plugin AlwaysPullImages

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -199,6 +199,11 @@ func (c *Cluster) BuildKubeAPIProcess(prefixPath string) v3.Process {
 		baseEnabledAdmissionPlugins = append(baseEnabledAdmissionPlugins, "PodSecurityPolicy")
 	}
 
+	// AlwaysPullImages
+	if c.Services.KubeAPI.AlwaysPullImages {
+		baseEnabledAdmissionPlugins = append(baseEnabledAdmissionPlugins, "AlwaysPullImages")
+	}
+
 	// Admission control plugins
 	// Resolution order:
 	//   k8s_defaults.go K8sVersionServiceOptions


### PR DESCRIPTION
Option to add AlwaysPullImages admission plugin for CIS Benchmark best practices.

> Setting admission control policy to AlwaysPullImages forces every new pod to pull the
required images every time. In a multi-tenant cluster users can be assured that their
private images can only be used by those who have the credentials to pull them.

Requires rancher/types#650
