### PR TITLE
WIP - CIS Benchmark - Secrets encryption config

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -42,6 +42,7 @@ type Cluster struct {
 	DockerDialerFactory              hosts.DialerFactory
 	EtcdHosts                        []*hosts.Host
 	EtcdReadyHosts                   []*hosts.Host
+	Force                            bool
 	InactiveHosts                    []*hosts.Host
 	K8sWrapTransport                 k8s.WrapTransport
 	KubeClient                       *kubernetes.Clientset
@@ -154,6 +155,7 @@ func InitClusterObject(ctx context.Context, rkeConfig *v3.RancherKubernetesEngin
 		ConfigDir:                     flags.ConfigDir,
 		DinD:                          flags.DinD,
 		CertificateDir:                flags.CertificateDir,
+		Force:                         flags.Force,
 		StateFilePath:                 GetStateFilePath(flags.ClusterFilePath, flags.ConfigDir),
 		PrivateRegistriesMap:          make(map[string]v3.PrivateRegistry),
 	}

--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -60,6 +60,7 @@ type ExternalFlags struct {
 	ConfigDir        string
 	CustomCerts      bool
 	DisablePortCheck bool
+	Force            bool
 	GenerateCSR      bool
 	Local            bool
 	UpdateOnly       bool
@@ -145,7 +146,6 @@ func (c *Cluster) setClusterDefaults(ctx context.Context) error {
 		}
 		c.PrivateRegistriesMap[pr.URL] = pr
 	}
-
 	err := c.setClusterImageDefaults()
 	if err != nil {
 		return err

--- a/cluster/encryption.go
+++ b/cluster/encryption.go
@@ -1,0 +1,152 @@
+package cluster
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/rancher/rke/k8s"
+	"github.com/rancher/rke/services"
+	"github.com/rancher/rke/templates"
+	"github.com/sirupsen/logrus"
+)
+
+// DeploySecretsEncryptionConfig -  Deploy encryption.yaml to ControlPlane hosts.
+func (c *Cluster) DeploySecretsEncryptionConfig(ctx context.Context, currentCluster *Cluster) error {
+	if currentCluster == nil {
+		currentCluster = &Cluster{}
+	}
+
+	if c.Services.KubeAPI.SecretsEncryptionConfig == currentCluster.Services.KubeAPI.SecretsEncryptionConfig {
+		logrus.Debug("[controlplane] Secrets encryption config matches state. No changes needed.")
+		return nil
+	}
+
+	for _, host := range c.ControlPlaneHosts {
+		err := c.WriteFile(ctx, host, "controlplane", "/etc/kubernetes/encryption.yaml", "0600", c.Services.KubeAPI.SecretsEncryptionConfig)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReconcileSecretsEncryptionConfig - Restart controlplane and replace all secrets in the cluster when the encryption config changes.
+func (c *Cluster) ReconcileSecretsEncryptionConfig(ctx context.Context, currentCluster *Cluster) error {
+	if currentCluster != nil {
+		if c.Services.KubeAPI.SecretsEncryptionConfig == currentCluster.Services.KubeAPI.SecretsEncryptionConfig {
+			logrus.Debug("[reconcile] Secrets encryption config matches. No changes needed.")
+			return nil
+		}
+
+		logrus.Info("[reconcile] New secrets encryption config. Updating existing secrets to apply encryption.")
+
+		err := services.RestartControlPlane(ctx, c.ControlPlaneHosts)
+		if err != nil {
+			return err
+		}
+
+		kubeClient, err := k8s.NewClient(c.LocalKubeConfigPath, c.K8sWrapTransport)
+		if err != nil {
+			return fmt.Errorf("Failed to initialize new kubernetes client: %v", err)
+		}
+
+		secrets, err := k8s.GetAllSecrets(kubeClient)
+		if err != nil {
+			return err
+		}
+
+		for _, secret := range secrets {
+			err = k8s.UpdateSecretObject(kubeClient, &secret)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Need some logic to keep users from shooting themselves in the foot.
+// If you rotate keys without the old key in the list you will lock yourself out of the existing secrets.
+// Ways people will break this:
+// - Add a config after a cluster is up with a generated config
+// - Change a config without putting the old key in the list before re-create of secrets.
+
+// SetSecretsEncryptionConfig - Set a default encryption config and secret if not provided.
+func (c *Cluster) SetSecretsEncryptionConfig(currentCluster *Cluster) error {
+	if currentCluster == nil {
+		currentCluster = &Cluster{}
+	}
+	// cluster.yaml not defined or populated
+	if len(c.Services.KubeAPI.SecretsEncryptionConfig) == 0 {
+		// Generate from template if not populated in current config.
+		if len(currentCluster.Services.KubeAPI.SecretsEncryptionConfig) == 0 {
+			clusterMajorVersion := getTagMajorVersion(c.Version)
+			encSecretKey := make([]byte, 32)
+			_, err := rand.Read(encSecretKey)
+			if err != nil {
+				return err
+			}
+			encConfig := &bytes.Buffer{}
+			secret := struct {
+				Secret string
+			}{
+				Secret: base64.StdEncoding.EncodeToString(encSecretKey),
+			}
+
+			_, ok := templates.EncryptionConfigurationTemplate[clusterMajorVersion]
+			if !ok {
+				return fmt.Errorf("Unsupported Kubernetes version, no encryption config template available: %s", c.Version)
+			}
+			encTemplate := template.New("encryption.yaml")
+			encTemplate, err = encTemplate.Parse(templates.EncryptionConfigurationTemplate[clusterMajorVersion])
+			if err != nil {
+				return err
+			}
+			err = encTemplate.Execute(encConfig, secret)
+			if err != nil {
+				return err
+			}
+
+			c.Services.KubeAPI.SecretsEncryptionConfig = encConfig.String()
+		} else {
+			// set previous cluster config (c is populated with cluster.yml, so currently empty)
+			c.Services.KubeAPI.SecretsEncryptionConfig = currentCluster.Services.KubeAPI.SecretsEncryptionConfig
+		}
+		// cluster.yml is defined.
+	} else {
+		// Should be a new cluster - just let it pass
+		if len(currentCluster.Services.KubeAPI.SecretsEncryptionConfig) == 0 {
+			return nil
+		}
+		// cluster.yml equals current config
+		if c.Services.KubeAPI.SecretsEncryptionConfig == currentCluster.Services.KubeAPI.SecretsEncryptionConfig {
+			return nil
+		}
+		// cluster.yml is different than current config
+		// Are you sure you know what you are doing?
+		if !c.Force {
+			reader := bufio.NewReader(os.Stdin)
+			logrus.Warn("A new secrets encryption configuration has been detected!")
+			logrus.Warn("Improper configuration may result in kube-apiserver failing to start and permanently losing access to stored secrets.")
+			logrus.Warn("For details on using or changing a custom encryption configuration see:")
+			logrus.Warn("https://rancher.com/docs/rke/v0.1.x/en/config-options/services/kube-api")
+			fmt.Print("Are you sure you want to continue [y/n]: ")
+			input, err := reader.ReadString('\n')
+			input = strings.TrimSpace(input)
+			if err != nil {
+				return err
+			}
+			if input != "y" && input != "Y" {
+				return fmt.Errorf("Aborted")
+			}
+		}
+	}
+	return nil
+}

--- a/cluster/write-file.go
+++ b/cluster/write-file.go
@@ -1,0 +1,68 @@
+package cluster
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/docker/docker/api/types/container"
+	"github.com/rancher/rke/docker"
+	"github.com/rancher/rke/hosts"
+	"github.com/rancher/rke/log"
+	"github.com/sirupsen/logrus"
+	"path/filepath"
+)
+
+// WriteFile - Writes file to Node.
+func (c *Cluster) WriteFile(ctx context.Context, host *hosts.Host, role string, path string, mode string, content string) error {
+	log.Infof(ctx, "[%s] Deploying file %s on node [%s]", role, path, host.Address)
+	err := c.doWriteFile(ctx, host, role, path, mode, content)
+	if err != nil {
+		return fmt.Errorf("[%s] Failed to file %s on node [%s]: %v", role, path, host.Address, err)
+	}
+	logrus.Debugf("[%s] Successfully deployed %s on node [%s]", role, path, host.Address)
+
+	return nil
+}
+
+func (c *Cluster) doWriteFile(ctx context.Context, host *hosts.Host, role string, path string, mode string, content string) error {
+	isRunning, err := docker.IsContainerRunning(ctx, host.DClient, host.Address, "deploy-file", true)
+	if err != nil {
+		return err
+	}
+	if isRunning {
+		err = docker.DoRemoveContainer(ctx, host.DClient, "write-file", host.Address)
+		if err != nil {
+			return err
+		}
+	}
+
+	b64Content := base64.StdEncoding.EncodeToString([]byte(content))
+	pathDir := filepath.Dir(path)
+	imageCfg := &container.Config{
+		Image: c.SystemImages.Alpine,
+		Cmd: []string{
+			"sh",
+			"-c",
+			fmt.Sprintf("cp -f %s %s-$(date -Iseconds -u); echo \"%s\" | base64 -d > %s && chmod %s %s", path, path, b64Content, path, mode, path),
+		},
+	}
+	hostCfg := &container.HostConfig{
+		Binds: []string{
+			fmt.Sprintf("%s:%s:z", pathDir, pathDir),
+		},
+	}
+
+	// Start container
+	err = docker.DoRunContainer(ctx, host.DClient, imageCfg, hostCfg, "write-file", host.Address, role, c.PrivateRegistriesMap)
+	if err != nil {
+		return err
+	}
+
+	// Remove container
+	err = docker.DoRemoveContainer(ctx, host.DClient, "write-file", host.Address)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/k8s/secret.go
+++ b/k8s/secret.go
@@ -11,6 +11,25 @@ func GetSecret(k8sClient *kubernetes.Clientset, secretName string) (*v1.Secret, 
 	return k8sClient.CoreV1().Secrets(metav1.NamespaceSystem).Get(secretName, metav1.GetOptions{})
 }
 
+// GetAllSecrets - Iterate through namespaces and return a slice of secrets.
+func GetAllSecrets(k8sClient *kubernetes.Clientset) ([]v1.Secret, error) {
+	secrets := []v1.Secret{}
+	namespaces, err := k8sClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ns := range namespaces.Items {
+		s, err := k8sClient.CoreV1().Secrets(ns.ObjectMeta.Name).List(metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		secrets = append(secrets, s.Items...)
+	}
+
+	return secrets, nil
+}
+
 func UpdateSecret(k8sClient *kubernetes.Clientset, secretDataMap map[string][]byte, secretName string) error {
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -25,6 +44,24 @@ func UpdateSecret(k8sClient *kubernetes.Clientset, secretDataMap map[string][]by
 		}
 		// update secret if its already exist
 		if _, err := k8sClient.CoreV1().Secrets(metav1.NamespaceSystem).Update(secret); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UpdateSecretObject - Update a secret with v1.Secret object.
+func UpdateSecretObject(k8sClient *kubernetes.Clientset, secret *v1.Secret) error {
+	// Clear version so we can submit as update.
+	secret.SetResourceVersion("")
+	_, err := k8sClient.CoreV1().Secrets(secret.ObjectMeta.Namespace).Create(secret)
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		// update secret if its already exist
+		_, err := k8sClient.CoreV1().Secrets(secret.ObjectMeta.Namespace).Update(secret)
+		if err != nil {
 			return err
 		}
 	}

--- a/templates/encryption.go
+++ b/templates/encryption.go
@@ -1,0 +1,40 @@
+package templates
+
+// Secrets encryption template. Secret is 32byte base64 encoded string.
+var (
+	EncryptionConfigurationTemplate = map[string]string{
+		"v1.13": `apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: {{ .Secret }}
+    - identity: {}`,
+		"v1.12": `apiVersion: v1
+kind: EncryptionConfig
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: {{ .Secret }}
+    - identity: {}`,
+		"v1.11": `apiVersion: v1
+kind: EncryptionConfig
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: {{ .Secret }}
+    - identity: {}`,
+	}
+)

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,4 +28,4 @@ github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0e
 github.com/mattn/go-colorable            efa589957cd060542a26d2dd7832fd6a6c6c3ade
 github.com/mattn/go-isatty               6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 github.com/rancher/norman                0557aa4ff31a3a0f007dcb1b684894f23cda390c
-github.com/rancher/types                 53be67a82da143abf0b7a6c93f2d0ce86e5d3877 
+github.com/rancher/types                 fe5fd7c1dd1187b54eb09cd27ef685a32b81d253 https://github.com/jgreat/types.git

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -47,6 +47,7 @@ const (
 	ClusterConditionAgentDeployed              condition.Cond = "AgentDeployed"
 	ClusterConditionGlobalAdminsSynced         condition.Cond = "GlobalAdminsSynced"
 	ClusterConditionInitialRolesPopulated      condition.Cond = "InitialRolesPopulated"
+	ClusterConditionServiceAccountMigrated     condition.Cond = "ServiceAccountMigrated"
 	ClusterConditionPrometheusOperatorDeployed condition.Cond = "PrometheusOperatorDeployed"
 	ClusterConditionMonitoringEnabled          condition.Cond = "MonitoringEnabled"
 	ClusterConditionAlertingEnabled            condition.Cond = "AlertingEnabled"

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/globaldns_types.go
@@ -48,8 +48,8 @@ type GlobalDNSProviderSpec struct {
 
 type Route53ProviderConfig struct {
 	RootDomain string `json:"rootDomain" norman:"required"`
-	AccessKey  string `json:"accessKey"`
-	SecretKey  string `json:"secretKey" norman:"type=password"`
+	AccessKey  string `json:"accessKey" norman:"required"`
+	SecretKey  string `json:"secretKey" norman:"required,type=password"`
 }
 
 type CloudflareProviderConfig struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
@@ -36,8 +36,9 @@ var (
 	K8sVersionServiceOptions = map[string]KubernetesServicesOptions{
 		"v1.13": {
 			KubeAPI: map[string]string{
-				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"tls-cipher-suites":          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"enable-admission-plugins":   "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"encryption-provider-config": "/etc/kubernetes/encryption.yaml",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
@@ -45,8 +46,9 @@ var (
 		},
 		"v1.12": {
 			KubeAPI: map[string]string{
-				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"tls-cipher-suites":                       "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"enable-admission-plugins":                "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"experimental-encryption-provider-config": "/etc/kubernetes/encryption.yaml",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
@@ -54,8 +56,9 @@ var (
 		},
 		"v1.11": {
 			KubeAPI: map[string]string{
-				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"tls-cipher-suites":                       "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"enable-admission-plugins":                "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"experimental-encryption-provider-config": "/etc/kubernetes/encryption.yaml",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
@@ -64,9 +67,10 @@ var (
 		},
 		"v1.10": {
 			KubeAPI: map[string]string{
-				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"endpoint-reconciler-type": "lease",
-				"enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"tls-cipher-suites":                       "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"endpoint-reconciler-type":                "lease",
+				"enable-admission-plugins":                "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"experimental-encryption-provider-config": "/etc/kubernetes/encryption.yaml",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
@@ -75,8 +79,9 @@ var (
 		},
 		"v1.9": {
 			KubeAPI: map[string]string{
-				"endpoint-reconciler-type": "lease",
-				"admission-control":        "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
+				"endpoint-reconciler-type":                "lease",
+				"admission-control":                       "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
+				"experimental-encryption-provider-config": "/etc/kubernetes/encryption.yaml",
 			},
 			Kubelet: map[string]string{
 				"cadvisor-port": "0",

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
@@ -218,6 +218,8 @@ type KubeAPIService struct {
 	PodSecurityPolicy bool `yaml:"pod_security_policy" json:"podSecurityPolicy,omitempty"`
 	// Enable/Disable AlwaysPullImages admissions plugin
 	AlwaysPullImages bool `yaml:"always_pull_images" json:"always_pull_images,omitempty"`
+	// Configuration for secrets encryption provider. https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#understanding-the-encryption-at-rest-configuration
+	SecretsEncryptionConfig string `yaml:"secrets_encryption_config" json:"secretsEncryptionConfig,omitempty"`
 }
 
 type KubeControllerService struct {


### PR DESCRIPTION
Add support for secrets encryption config.

* Default to generating an encryption config using recommended `asecbc` with a random key.
* User can specify their own provider.
* Warn and require acknowledgement (I know what I'm doing) if user tries to change or provide custom provider after cluster already has a provider set up. If you mess your config up: at best the kube-apiserver won't start, at worst you can lock yourself out of your secrets. 
* add `--force` flag to `up` to bypass warning prompt.
* Restart `controlplane` services if config is changed. 
* Replace secrets to apply new encryption if config changes, or when config is applied to a cluster built with previous version of RKE.

---

k8s/secrets.go
* Add function to get all secrets in a cluster.
* Add function to replace all secrets in a cluster.

--- 

templates/encryption.go
* add templates for 1.8 -> 1.13

---

cluster/write-file.go
* more generic way to write and permission files to a host
* will create timestamped back up of files it overwrites (just in case)

---

cmd/up.go
* add `--force` - I know what I'm doing - flag 
* add in triggers for creating the generated config and reconcile secretes to apply encryption.

---

cluster/defaults.go
cluster/state.go
cmd/remove.go
cmd/etcd.go
cmd/cert.go
* Add support for `--force` flag 

---

### Testing: 

* New cluster generated config
* New cluster provided config
* Update cluster with provided config (rotate keys)
* Previous RKE cluster is now encrypted.

#### General procedure:

1. Create Cluster with previous version of RKE
2. Create secret
```
kubectl create secret generic secret1 -n default --from-literal=mykey=mydata
secret/secret1 created
```
3. Confirm secret
```
kubectl get secret secret1 -o jsonpath --template='{ .data.mykey }' | base64 -d

mydata%
```
4. Update cluster with new RKE (this should generate, apply config and recreate all the secrets so they are encrypted)
5. Confirm you can still read secret
 ```
kubectl get secret secret1 -o jsonpath --template='{ .data.mykey }' | base64 -d

mydata%
```
5. Exec into etcd container and confirm encryption has been applied. Look for `enc:aescbc:v1:key1`. This will tell you the encryption provider and which key is being used for the secret.
```
etcd etcdctl get /registry/secrets/default/secret1 | hexdump -C

00000000  2f 72 65 67 69 73 74 72  79 2f 73 65 63 72 65 74  |/registry/secret|
00000010  73 2f 64 65 66 61 75 6c  74 2f 73 65 63 72 65 74  |s/default/secret|
00000020  31 0a 6b 38 73 3a 65 6e  63 3a 61 65 73 63 62 63  |1.k8s:enc:aescbc|
00000030  3a 76 31 3a 6b 65 79 31  3a 37 01 ba 0c 82 30 f8  |:v1:key1:7....0.|
00000040  9a 57 3a ff 7f 5d a9 49  9d 4b 84 09 c2 43 b4 4a  |.W:..].I.K...C.J|
00000050  4d 93 d3 43 98 bf 48 62  21 f1 c8 1e c6 68 bc 05  |M..C..Hb!....h..|
00000060  41 d6 a0 11 3a 39 e9 55  c4 8d 3a 20 84 44 94 99  |A...:9.U..: .D..|
00000070  63 bf ea 3c 44 db ae 0f  18 14 d9 6f d2 84 37 12  |c..<D......o..7.|
00000080  26 72 35 96 ab 38 22 6f  88 c1 12 5a 66 90 87 3d  |&r5..8"o...Zf..=|
00000090  96 dd a7 cb b8 e7 8b 3d  7e 4a 8f c6 b1 e6 5f ac  |.......=~J...._.|
000000a0  73 3c de 44 a6 d0 ac fe  0d d7 aa a0 d9 5d c9 79  |s<.D.........].y|
000000b0  ec ef 12 3b d4 d6 a0 d9  91 f0 ab 73 0b 3f 85 e3  |...;.......s.?..|
000000c0  f6 e2 d5 54 b7 bc c3 ad  aa 0a                    |...T......|
000000ca
```

#### Example provided config `cluster.yml`
Secret is 32 byte base64 encoded string.
```yaml
 services:
  kube-api:
    secrets_encryption_config: |-
      apiVersion: v1
      kind: EncryptionConfig
      resources:
        - resources:
          - secrets
          providers:
          - aescbc:
              keys:
              - name: key1
                secret: qsJXfHuNtQV2othYw6ihJLGj9U5XPi1ThQYcS1XJJ5A=
          - identity: {}
```

#### Example rotating keys
Previous key must be included in the provider list so encrypted secrets can still be read.
```yaml
 services:
  kube-api:
    secrets_encryption_config: |-
      apiVersion: v1
      kind: EncryptionConfig
      resources:
        - resources:
          - secrets
          providers:
          - aescbc:
              keys:
              - name: key2
                secret: UIt8QL3hRjrWZJWV5hZsNWFNFtQyKZovKxESplYiFq0=
              - name: key1
                secret: qsJXfHuNtQV2othYw6ihJLGj9U5XPi1ThQYcS1XJJ5A=
          - identity: {}
```