### PR TITLE
Don't schedule kubedns to Windows node

### DIFF
--- a/templates/kubedns.go
+++ b/templates/kubedns.go
@@ -15,6 +15,15 @@ spec:
       labels:
         k8s-app: kube-dns-autoscaler
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: beta.kubernetes.io/os
+                  operator: NotIn
+                  values:
+                    - windows
       serviceAccountName: kube-dns-autoscaler
       containers:
       - name: autoscaler
@@ -124,6 +133,14 @@ spec:
                     operator: In
                     values: ["kube-dns"]
               topologyKey: kubernetes.io/hostname
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: beta.kubernetes.io/os
+                  operator: NotIn
+                  values:
+                    - windows
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"


### PR DESCRIPTION
**Problem:**
Schedule kubedns component to Windows node will cause DNS doesn't work
well

**Solution:**
Add nodeAffinity to kubedns

**Issue:**
https://github.com/rancher/rancher/issues/17423