### PR TITLE
[WIP] Create arm64 kubernetes by rke

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install -y gcc ca-certificates git wget curl vim less file kmod iptables xz-utils zip && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64  GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
@@ -16,6 +16,7 @@ RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+    DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
     DOCKER_URL=DOCKER_URL_${ARCH}
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker

--- a/util/util.go
+++ b/util/util.go
@@ -108,3 +108,47 @@ func ValidateVersion(version string) error {
 
 	return nil
 }
+
+// ValidateArm64Version - Return error if version is not valid
+// Is version major.minor >= oldest major.minor supported
+// Is version in the AllArm64K8sVersions list
+// Is version not in the "bad" list
+func ValidateArm64Version(version string) error {
+	// Create target version and current versions list
+	targetVersion, err := StrToSemVer(version)
+	if err != nil {
+		return fmt.Errorf("%s is not valid semver", version)
+	}
+	currentVersionsList := []*semver.Version{}
+	for _, ver := range v3.Arm64K8sVersionsCurrent {
+		v, err := StrToSemVer(ver)
+		if err != nil {
+			return fmt.Errorf("%s in Current Versions list is not valid semver", ver)
+		}
+
+		currentVersionsList = append(currentVersionsList, v)
+	}
+
+	// Make sure Target version is greater than or equal to oldest major.minor supported.
+	semver.Sort(currentVersionsList)
+	if targetVersion.Major < currentVersionsList[0].Major {
+		return fmt.Errorf("%s is an unsupported Kubernetes version - see 'rke config --system-images --all' for versions supported with this release", version)
+	}
+	if targetVersion.Major == currentVersionsList[0].Major {
+		if targetVersion.Minor < currentVersionsList[0].Minor {
+			return fmt.Errorf("%s is an unsupported Kubernetes version - see 'rke config --system-images --all' for versions supported with this release", version)
+		}
+	}
+	// Make sure Target version is in the AllK8sVersions list.
+	_, ok := v3.AllArm64K8sVersions[version]
+	if !ok {
+		return fmt.Errorf("%s is an unsupported Kubernetes version - see 'rke config --system-images --all' for versions supported with this release", version)
+	}
+	// Make sure Target version is not "bad".
+	_, ok = v3.K8sBadVersions[version]
+	if ok {
+		return fmt.Errorf("%s is an unsupported Kubernetes version - see 'rke config --system-images --all' for versions supported with this release", version)
+	}
+
+	return nil
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,4 +28,4 @@ github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0e
 github.com/mattn/go-colorable            efa589957cd060542a26d2dd7832fd6a6c6c3ade
 github.com/mattn/go-isatty               6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 github.com/rancher/norman                0557aa4ff31a3a0f007dcb1b684894f23cda390c
-github.com/rancher/types                 53be67a82da143abf0b7a6c93f2d0ce86e5d3877 
+github.com/rancher/types                 rke-multiarch-support                    https://github.com/jianghang8421/types.git

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_arm64_defaults.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_arm64_defaults.go
@@ -1,0 +1,133 @@
+package v3
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	DefaultArm64K8s = "v1.11.6-rancher1-1"
+)
+
+var (
+	Arm64K8sVersionsCurrent = []string{
+		"v1.11.6-rancher1-1",
+		"v1.12.5-rancher1-1",
+		"v1.13.1-rancher1-1",
+	}
+
+	// Arm64K8sVersionToRKESystemImages is dynamically populated on init() with the latest versions
+	Arm64K8sVersionToRKESystemImages map[string]RKESystemImages
+
+	AllArm64K8sVersions = map[string]RKESystemImages{
+		"v1.11.6-rancher1-1": {
+			Etcd:                      m("jianghang8421/coreos-etcd-arm64:v3.2.18"),
+			Kubernetes:                m("jianghang8421/hyperkube:v1.11.6-rancher1"),
+			Alpine:                    m("jianghang8421/rke-tools:v0.1.18"),
+			NginxProxy:                m("jianghang8421/rke-tools:v0.1.18"),
+			CertDownloader:            m("jianghang8421/rke-tools:v0.1.18"),
+			KubernetesServicesSidecar: m("jianghang8421/rke-tools:v0.1.18"),
+			KubeDNS:                   m("jianghang8421/k8s-dns-kube-dns-arm64:1.14.10"),
+			DNSmasq:                   m("jianghang8421/k8s-dns-dnsmasq-nanny-arm64:1.14.10"),
+			KubeDNSSidecar:            m("jianghang8421/k8s-dns-sidecar-arm64:1.14.10"),
+			KubeDNSAutoscaler:         m("jianghang8421/cluster-proportional-autoscaler-arm64:1.0.0"),
+			Flannel:                   m("jianghang8421/coreos-flannel-arm64:v0.10.0"),
+			FlannelCNI:                m("jianghang8421/coreos-flannel-cni-arm64:v0.3.0"),
+			CalicoNode:                m("quay.io/calico/node:v3.1.3"),
+			CalicoCNI:                 m("quay.io/calico/cni:v3.1.3"),
+			CalicoCtl:                 m("quay.io/calico/ctl:v2.0.0"),
+			CanalNode:                 m("quay.io/calico/node:v3.1.3"),
+			CanalCNI:                  m("quay.io/calico/cni:v3.1.3"),
+			CanalFlannel:              m("quay.io/coreos/flannel:v0.10.0"),
+			WeaveNode:                 m("weaveworks/weave-kube:2.1.2"),
+			WeaveCNI:                  m("weaveworks/weave-npc:2.1.2"),
+			PodInfraContainer:         m("jianghang8421/pause-arm64:3.1"),
+			Ingress:                   m("jianghang8421/nginx-ingress-controller:0.21.0-rancher1"),
+			IngressBackend:            m("jianghang8421/nginx-ingress-controller-defaultbackend-arm64:1.4"),
+			MetricsServer:             m("jianghang8421/metrics-server-arm64:v0.2.1"),
+		},
+		"v1.12.5-rancher1-1": {
+			Etcd:                      m("jianghang8421/coreos-etcd-arm64:v3.2.24"),
+			Kubernetes:                m("jianghang8421/hyperkube:v1.12.5-rancher1"),
+			Alpine:                    m("jianghang8421/rke-tools:v0.1.23"),
+			NginxProxy:                m("jianghang8421/rke-tools:v0.1.23"),
+			CertDownloader:            m("jianghang8421/rke-tools:v0.1.23"),
+			KubernetesServicesSidecar: m("jianghang8421/rke-tools:v0.1.23"),
+			KubeDNS:                   m("jianghang8421/k8s-dns-kube-dns-arm64:1.14.13"),
+			DNSmasq:                   m("jianghang8421/k8s-dns-dnsmasq-nanny-arm64:1.14.13"),
+			KubeDNSSidecar:            m("jianghang8421/k8s-dns-sidecar-arm64:1.14.13"),
+			KubeDNSAutoscaler:         m("jianghang8421/cluster-proportional-autoscaler-arm64:1.0.0"),
+			Flannel:                   m("jianghang8421/coreos-flannel-arm64:v0.10.0"),
+			FlannelCNI:                m("jianghang8421/coreos-flannel-cni-arm64:v0.3.0"),
+			CalicoNode:                m("quay.io/calico/node:v3.1.3"),
+			CalicoCNI:                 m("quay.io/calico/cni:v3.1.3"),
+			CalicoCtl:                 m("quay.io/calico/ctl:v2.0.0"),
+			CanalNode:                 m("quay.io/calico/node:v3.1.3"),
+			CanalCNI:                  m("quay.io/calico/cni:v3.1.3"),
+			CanalFlannel:              m("quay.io/coreos/flannel:v0.10.0"),
+			WeaveNode:                 m("weaveworks/weave-kube:2.5.0"),
+			WeaveCNI:                  m("weaveworks/weave-npc:2.5.0"),
+			PodInfraContainer:         m("jianghang8421/pause-arm64:3.1"),
+			Ingress:                   m("jianghang8421/nginx-ingress-controller:0.21.0-rancher1"),
+			IngressBackend:            m("jianghang8421/nginx-ingress-controller-defaultbackend-arm64:1.4"),
+			MetricsServer:             m("jianghang8421/metrics-server-arm64:v0.3.1"),
+			CoreDNS:                   m("coredns/coredns:1.2.2"),
+			CoreDNSAutoscaler:         m("jianghang8421/cluster-proportional-autoscaler-arm64:1.0.0"),
+		},
+		"v1.13.1-rancher1-1": {
+			Etcd:                      m("jianghang8421/coreos-etcd-arm64:v3.2.24"),
+			Kubernetes:                m("jianghang8421/hyperkube:v1.13.1-rancher1"),
+			Alpine:                    m("jianghang8421/rke-tools:v0.1.23"),
+			NginxProxy:                m("jianghang8421/rke-tools:v0.1.23"),
+			CertDownloader:            m("jianghang8421/rke-tools:v0.1.23"),
+			KubernetesServicesSidecar: m("jianghang8421/rke-tools:v0.1.23"),
+			KubeDNS:                   m("jianghang8421/k8s-dns-kube-dns-arm64:1.15.0"),
+			DNSmasq:                   m("jianghang8421/k8s-dns-dnsmasq-nanny-arm64:1.15.0"),
+			KubeDNSSidecar:            m("jianghang8421/k8s-dns-sidecar-arm64:1.15.0"),
+			KubeDNSAutoscaler:         m("jianghang8421/cluster-proportional-autoscaler-arm64:1.0.0"),
+			Flannel:                   m("jianghang8421/coreos-flannel-arm64:v0.10.0"),
+			FlannelCNI:                m("jianghang8421/coreos-flannel-cni-arm64:v0.3.0"),
+			CalicoNode:                m("quay.io/calico/node:v3.4.0"),
+			CalicoCNI:                 m("quay.io/calico/cni:v3.4.0"),
+			CalicoCtl:                 m("quay.io/calico/ctl:v2.0.0"),
+			CanalNode:                 m("quay.io/calico/node:v3.4.0"),
+			CanalCNI:                  m("quay.io/calico/cni:v3.4.0"),
+			CanalFlannel:              m("quay.io/coreos/flannel:v0.10.0"),
+			WeaveNode:                 m("weaveworks/weave-kube:2.5.0"),
+			WeaveCNI:                  m("weaveworks/weave-npc:2.5.0"),
+			PodInfraContainer:         m("jianghang8421/pause-arm64:3.1"),
+			Ingress:                   m("jianghang8421/nginx-ingress-controller:0.21.0-rancher1"),
+			IngressBackend:            m("jianghang8421/nginx-ingress-controller-defaultbackend-arm64:1.4"),
+			MetricsServer:             m("jianghang8421/metrics-server-arm64:v0.3.1"),
+			CoreDNS:                   m("coredns/coredns:1.2.6"),
+			CoreDNSAutoscaler:         m("jianghang8421/cluster-proportional-autoscaler-arm64:1.0.0"),
+		},
+	}
+)
+
+func initArm64() {
+	if Arm64K8sVersionToRKESystemImages != nil {
+		panic("Do not initialize or add values to Arm64K8sVersionToRKESystemImages")
+	}
+
+	Arm64K8sVersionToRKESystemImages = map[string]RKESystemImages{}
+
+	for version, images := range AllArm64K8sVersions {
+		longName := "jianghang8421/hyperkube:" + version
+		if !strings.HasPrefix(longName, images.Kubernetes) {
+			panic(fmt.Sprintf("For K8s version %s, the Kubernetes image tag should be a substring of %s, currently it is %s", version, version, images.Kubernetes))
+		}
+	}
+
+	for _, latest := range Arm64K8sVersionsCurrent {
+		images, ok := AllArm64K8sVersions[latest]
+		if !ok {
+			panic("K8s version " + " is not found in AllArm64K8sVersions map")
+		}
+		Arm64K8sVersionToRKESystemImages[latest] = images
+	}
+
+	if _, ok := Arm64K8sVersionToRKESystemImages[DefaultArm64K8s]; !ok {
+		panic("Default K8s version " + DefaultArm64K8s + " is not found in k8sVersionsCurrent list")
+	}
+}

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
@@ -850,4 +850,5 @@ func init() {
 
 	// init Windows versions
 	initWindows()
+	initArm64()
 }

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
@@ -27,6 +27,8 @@ type RancherKubernetesEngineConfig struct {
 	IgnoreDockerVersion bool `yaml:"ignore_docker_version" json:"ignoreDockerVersion" norman:"default=true"`
 	// Kubernetes version to use (if kubernetes image is specifed, image version takes precedence)
 	Version string `yaml:"kubernetes_version" json:"kubernetesVersion,omitempty"`
+	// Kubernetes Architecture to use: now only support amd64 and arm64
+	Architecture string `yaml:"architecture" json:"architecture,omitempty" norman:"default=amd64"`
 	// List of private registries and their credentials
 	PrivateRegistries []PrivateRegistry `yaml:"private_registries" json:"privateRegistries,omitempty"`
 	// Ingress controller used in the cluster


### PR DESCRIPTION
This PR includes the following changes.
- Add `architecture` config item in `rancher/types` for rke to create arm64 k8s.
- Add arm64 default system images in `rancher/types` for rke to create arm64 k8s.
- Add drone1.0 config file for CICD.

Depends on these changes, users can create an arm64 kubernetes cluster by rke using following config.
```yaml
nodes:
    - address: 1.2.3.4
      user: ubuntu
      role:
        - controlplane
        - etcd
        - worker
architecture: arm64
services:
    etcd:
        extra_env:
            - ETCD_UNSUPPORTED_ARCH=arm64
network:
    plugin: flannel
```
**The enviroment variable`ETCD_UNSUPPORTED_ARCH` needs to be set to start the arm64 etcd.
Now only support `Flannel` network plugin on arm64**

The `quay.io/coreos/flannel-cni:v0.3.0` image doesn't provide the official arm64 version. So I forked this to my repo [jianghang8421/flannel-cni](https://github.com/jianghang8421/flannel-cni/tree/v0.3.x-fix) and release the arm64 image.

**Now the arm64 default system images are still using my own test images. These images need to be modified to rancher's official images when all the images are published to rancher's official docker hub.**

Issue
https://github.com/rancher/rancher/issues/16461
https://github.com/rancher/rancher/issues/16518
