### PR TITLE
Convert aarch64 to arm64 for ETCD_UNSUPPORTED_ARCH env var

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -775,6 +775,10 @@ func (c *Cluster) BuildEtcdProcess(host *hosts.Host, etcdHosts []*hosts.Host, pr
 	Env = append(Env, fmt.Sprintf("ETCDCTL_CACERT=%s", pki.GetCertPath(pki.CACertName)))
 	Env = append(Env, fmt.Sprintf("ETCDCTL_CERT=%s", pki.GetCertPath(nodeName)))
 	Env = append(Env, fmt.Sprintf("ETCDCTL_KEY=%s", pki.GetKeyPath(nodeName)))
+
+	if architecture == "aarch64" {
+		architecture = "arm64"
+	}
 	Env = append(Env, fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=%s", architecture))
 
 	Env = append(Env, c.Services.Etcd.ExtraEnv...)


### PR DESCRIPTION
On the ARM64 platform, ETCD_UNSUPPORTED_ARCH env var cannot recognize `aarch64`, so we need to convert `aarch64` to `arm64`.

https://github.com/rancher/rancher/issues/16518