### PR TITLE
Fix flannel issue with k8s 1.13

### DIFF
--- a/templates/flannel.go
+++ b/templates/flannel.go
@@ -157,7 +157,7 @@ spec:
           mountPath: /host/opt/cni/bin/
       hostNetwork: true
       tolerations:
-      {{- if eq .ClusterVersion "v1.12" }}
+      {{- if ge .ClusterVersion "v1.12" }}
       - operator: Exists
         effect: NoSchedule
       - operator: Exists


### PR DESCRIPTION
This is a small update to the change made in https://github.com/rancher/rke/commit/24a84659415ae23aa4085e190c3238964ef0ad97#diff-7276c3d6a641862f48aed87f62158904, applying the updated tolerations to k8s 1.12 and above, to account for the default k8s 1.13 install on RKE v0.1.17.