### PR TITLE
Do *preliminary* nc KubeAPI port check using HTTP (not raw TCP)

### DIFF
--- a/cluster/network.go
+++ b/cluster/network.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -291,13 +292,20 @@ func (c *Cluster) CheckClusterPorts(ctx context.Context, currentCluster *Cluster
 func (c *Cluster) checkKubeAPIPort(ctx context.Context) error {
 	log.Infof(ctx, "[network] Checking KubeAPI port Control Plane hosts")
 	for _, host := range c.ControlPlaneHosts {
-		logrus.Debugf("[network] Checking KubeAPI port [%s] on host: %s", KubeAPIPort, host.Address)
+		logrus.Debugf("[network] TCP dialing KubeAPI port [%s] on host: %s", KubeAPIPort, host.Address)
 		address := fmt.Sprintf("%s:%s", host.Address, KubeAPIPort)
-		conn, err := net.Dial("tcp", address)
-		if err != nil {
-			return fmt.Errorf("[network] Can't access KubeAPI port [%s] on Control Plane host: %s", KubeAPIPort, host.Address)
+		tcpConn, err := net.Dial("tcp", address)
+		if err == nil {
+			tcpConn.Close()
+		} else {
+			// Try to connect using HTTP
+			logrus.Debugf("[network] Failed to TCP dial [%s:%s], re-trying with an HTTP client...", host.Address, KubeAPIPort)
+			resp, err := http.Get("http://" + address)
+			if err != nil {
+				return fmt.Errorf("[network] Can't access KubeAPI port [%s] on Control Plane host: %s", KubeAPIPort, host.Address)
+			}
+			defer resp.Body.Close()
 		}
-		conn.Close()
 	}
 	return nil
 }
@@ -345,12 +353,9 @@ func (c *Cluster) deployListener(ctx context.Context, host *hosts.Host, portList
 	imageCfg := &container.Config{
 		Image: c.SystemImages.Alpine,
 		Cmd: []string{
-			"nc",
-			"-kl",
-			"-p",
-			"1337",
-			"-e",
-			"echo",
+			"bash",
+			"-c",
+			"while true; do { echo -e \"HTTP/1.1 200 OK\" |  nc -kl -p 1337; } done",
 		},
 		ExposedPorts: nat.PortSet{
 			"1337/tcp": {},


### PR DESCRIPTION
This PR updates RKE's preliminary KubeAPI port check to fall back to HTTP when raw TCP fails to avoid potential firewall connectivity problems. 

Signed-off-by: Jesse Millan jlamillan@gmail.com