### PR TITLE
Prepend 3 dashes at the beginning of addon YAMLs. Resolve #1251

### DIFF
--- a/cluster/addons.go
+++ b/cluster/addons.go
@@ -160,6 +160,13 @@ func (c *Cluster) deployAddonsInclude(ctx context.Context) error {
 			if err := validateUserAddonYAML(addonYAML); err != nil {
 				return err
 			}
+
+			// Put 3 dashes (---) at beginning of next YAML if it is not there already so we can append to manifests
+			dashes := "---\n"
+			if !strings.HasPrefix(string(addonYAML[:]), dashes) {
+				addonYAML = append([]byte(dashes), addonYAML...)
+			}
+
 			manifests = append(manifests, addonYAML...)
 		} else if isFilePath(addon) {
 			addonYAML, err := ioutil.ReadFile(addon)


### PR DESCRIPTION
This PR ensures each YAML file in the `addons_include` section of `cluster.yml` begins with 3 dashes `---`. This is necessary so we can safely append all the manifests files regardless if they begin with `---`.

#1251.

Signed-off-by: Jesse Millan jlamillan@gmail.com 