### PR TITLE
Always re-run add-on deployment jobs to ensure they truley stay in sync.

### DIFF
--- a/k8s/job.go
+++ b/k8s/job.go
@@ -33,10 +33,11 @@ func ApplyK8sSystemJob(jobYaml, kubeConfigPath string, k8sWrapTransport WrapTran
 	if err != nil {
 		return err
 	}
-	// if the addon configMap is updated, or the previous job is not completed,
-	// I will remove the existing job first, if any
-	if addonUpdated || (jobStatus.Created && !jobStatus.Completed) {
-		logrus.Debugf("[k8s] replacing job %s.. ", job.Name)
+
+	// The safest way to ensure add-ons are in sync with the cluster.yaml is to always re-run the job and let
+	// kubectl apply determine what if any changes need to be made.
+	if addonUpdated || jobStatus.Created || jobStatus.Completed {
+		logrus.Debugf("[k8s] deleting job %s so that it can be recreated.. ", job.Name)
 		if err := DeleteK8sSystemJob(jobYaml, k8sClient, timeout); err != nil {
 			return err
 		}


### PR DESCRIPTION
RKE add-ons (network, dns, etc.) can get out of sync [[1](https://github.com/rancher/rke/issues/815),[2](https://github.com/rancher/rke/issues/1278)] with respect to the `cluster.yaml` file regardless of whether or not the `cluster.yaml` has been updated (e.g. `kubectl delete deployment kube-dns`).  

This PR ensures RKE add-ons are brought back in sync each time the `up` command is run by simply re-running the add-on deploy-jobs and letting `kubectl apply` do the heavy lifting of determining whether or not changes are actually required. If nothing has changed, re-running the jobs should not be a problem since they will be noops. 

 