### PR TITLE
Decrease calico/canal logging for K8s 1.13 templates

### DIFF
--- a/templates/calico.go
+++ b/templates/calico.go
@@ -675,7 +675,7 @@ data:
       "plugins": [
         {
           "type": "calico",
-          "log_level": "info",
+          "log_level": "WARNING",
           "datastore_type": "kubernetes",
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": __CNI_MTU__,
@@ -845,9 +845,15 @@ spec:
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"
-            # Set Felix logging to "info"
+            # Disable felix logging to file
+            - name: FELIX_LOGFILEPATH
+              value: "none"
+            # Disable felix logging for syslog
+            - name: FELIX_LOGSEVERITYSYS
+              value: ""
+            # Enable felix logging to stdout
             - name: FELIX_LOGSEVERITYSCREEN
-              value: "info"
+              value: "Warning"
             - name: FELIX_HEALTHENABLED
               value: "true"
           securityContext:

--- a/templates/canal.go
+++ b/templates/canal.go
@@ -762,7 +762,7 @@ data:
       "plugins": [
         {
           "type": "calico",
-          "log_level": "info",
+          "log_level": "WARNING",
           "datastore_type": "kubernetes",
           "nodename": "__KUBERNETES_NODE_NAME__",
           "ipam": {
@@ -919,9 +919,15 @@ spec:
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "false"
-            # Set Felix logging to "info"
+            # Disable felix logging to file
+            - name: FELIX_LOGFILEPATH
+              value: "none"
+            # Disable felix logging for syslog
+            - name: FELIX_LOGSEVERITYSYS
+              value: ""
+            # Enable felix logging to stdout
             - name: FELIX_LOGSEVERITYSCREEN
-              value: "info"
+              value: "Warning"
             - name: FELIX_HEALTHENABLED
               value: "true"
           securityContext:


### PR DESCRIPTION
The Canal and Calico templates for K8s 1.13 introduce a regression in the use of info vs warning log level. Initial decrease of log level in the templates was made in https://github.com/rancher/rke/commit/c00e6d2e9d272ea76ce8147fb7c163a34fb369ad#diff-3497e44efe766fa9ca127075b285d611L118

This decreases log verbosity to warning in the 1.13 templates.

https://github.com/rancher/rancher/issues/19472

