### PR TITLE
Added onetime container and active running checks

### DIFF
--- a/cluster/file-deployer.go
+++ b/cluster/file-deployer.go
@@ -49,7 +49,7 @@ func doDeployFile(ctx context.Context, host *hosts.Host, fileName, fileContents,
 			fmt.Sprintf("%s:/etc/kubernetes:z", path.Join(host.PrefixPath, "/etc/kubernetes")),
 		},
 	}
-	if err := docker.DoRunContainer(ctx, host.DClient, imageCfg, hostCfg, ContainerName, host.Address, ServiceName, prsMap); err != nil {
+	if err := docker.DoRunOnetimeContainer(ctx, host.DClient, imageCfg, hostCfg, ContainerName, host.Address, ServiceName, prsMap); err != nil {
 		return err
 	}
 	if err := docker.DoRemoveContainer(ctx, host.DClient, ContainerName, host.Address); err != nil {

--- a/hosts/hosts.go
+++ b/hosts/hosts.go
@@ -251,7 +251,11 @@ func IsHostListChanged(currentHosts, configHosts []*Host) bool {
 }
 
 func buildCleanerConfig(host *Host, toCleanDirs []string, cleanerImage string) (*container.Config, *container.HostConfig) {
-	cmd := append([]string{"rm", "-rf"}, toCleanDirs...)
+	cmd := []string{
+		"sh",
+		"-c",
+		fmt.Sprintf("find %s -mindepth 1 -delete", strings.Join(toCleanDirs, " ")),
+	}
 	imageCfg := &container.Config{
 		Image: cleanerImage,
 		Cmd:   cmd,


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/19438

* Differentiates running containers and onetime containers
* Remove the native Docker wait and implement active polling for actively checking container via Docker and to keep the tunnel active (if there is no reply within 50 seconds, the tunnel closes). This also solves etcd snaphots that take longer than 50 seconds to complete (https://github.com/rancher/rancher/issues/19496). The current hardcoded timeout is 300 retries with 1 second sleep each. (5 minutes)
* The new onetime container failed on `rke remove` due to `rm -rf` ing the bind mounted folder. This is replaced with using find like for the rke logs.
