### PR TITLE
[release/v0.2]: kube-proxy not mounting /run/xtables.lock leading to racy iptabl…

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -544,6 +544,7 @@ func (c *Cluster) BuildKubeProxyProcess(host *hosts.Host, prefixPath string) v3.
 	}
 	Binds := []string{
 		fmt.Sprintf("%s:/etc/kubernetes:z", path.Join(prefixPath, "/etc/kubernetes")),
+		"/run:/run",
 	}
 
 	for arg, value := range c.Services.Kubeproxy.ExtraArgs {


### PR DESCRIPTION
…es access

kube-proxy and other processes invoking iptables (e.g. flannel, weave) must share the host fs `/run/xtables.lock` to prevent concurrent access to iptables resulting in errors like "iptables: Resource temporarily unavailable".