### PR TITLE
Don't schedule Linux addons to Windows node

### DIFF
--- a/templates/metrics.go
+++ b/templates/metrics.go
@@ -106,6 +106,15 @@ spec:
       labels:
         k8s-app: metrics-server
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: beta.kubernetes.io/os
+                  operator: NotIn
+                  values:
+                    - windows
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server

--- a/templates/nginx-ingress.go
+++ b/templates/nginx-ingress.go
@@ -275,6 +275,15 @@ spec:
       labels:
         app: default-http-backend
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: beta.kubernetes.io/os
+                  operator: NotIn
+                  values:
+                    - windows
       terminationGracePeriodSeconds: 60
       containers:
       - name: default-http-backend


### PR DESCRIPTION
**Problem:**
Schedule default-http-backend and metrics-server to Windows node will be failed.

**Solution:**
Add nodeAffinity to default-http-backend and metrics-server workload
spec

**Issue:**
https://github.com/rancher/rancher/issues/19929