### PR TITLE
remove PersistentVolumeLabel controller

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -124,7 +124,6 @@ func (c *Cluster) BuildKubeAPIProcess(host *hosts.Host, prefixPath string) v3.Pr
 		"LimitRanger",
 		"NamespaceLifecycle",
 		"NodeRestriction",
-		"PersistentVolumeLabel",
 		"ResourceQuota",
 		"ServiceAccount",
 	}


### PR DESCRIPTION
It has been deprecated, adding it to baseEnabledAdmissionPlugins results into a warning, but the controller still gets loaded and affects the behavior for persistent volume creation. 

https://github.com/rancher/rancher/issues/19749