### PR TITLE
Use a provided `external-hostname` kube-apiserver arg in the kubeconfig and during RKE provisioning

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rancher/rke/metadata"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 
 	"github.com/coreos/go-semver/semver"
 	ref "github.com/docker/distribution/reference"
@@ -16,6 +17,8 @@ import (
 
 const (
 	WorkerThreads = 50
+
+	externalHostname = "external-hostname"
 )
 
 func StrToSemVer(version string) (*semver.Version, error) {
@@ -138,4 +141,8 @@ func GetEnvVar(key string) (string, string, bool) {
 		return strings.ToLower(key), value, true
 	}
 	return "", "", false
+}
+
+func GetKubeAPIExternalHostname(rkeConfig *v3.RancherKubernetesEngineConfig) string {
+	return rkeConfig.Services.KubeAPI.ExtraArgs[externalHostname]
 }


### PR DESCRIPTION
If a cluster config contains

```
services:
  kube-api:
    extra_args:
      external-hostname: my-load-balancer.example.com
```

this value will be used as the primary means to communicate with the Kube API for setup and port checks, as well as will go into the generated certs and kube config file.

If these semantics may not be what you're looking for, perhaps you would prefer a type change to the cluster config and have a top-level value such as `external_kube_api_host` or something that intrinsically passes down to the `external-hostname` arg to kube-apiserver.

#705