### PR TITLE
always use DefaultRKETools for etcd snapshot

### DIFF
--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -20,9 +20,6 @@ const (
 
 func (c *Cluster) SnapshotEtcd(ctx context.Context, snapshotName string) error {
 	backupImage := c.getBackupImage()
-	if !util.IsRancherBackupSupported(c.SystemImages.Alpine) {
-		log.Warnf(ctx, "Auto local backup sync is not supported in `%s`. Using `%s` instead.", c.SystemImages.Alpine, backupImage)
-	}
 	for _, host := range c.EtcdHosts {
 		if err := services.RunEtcdSnapshotSave(ctx, host, c.PrivateRegistriesMap, backupImage, snapshotName, true, c.Services.Etcd); err != nil {
 			return err
@@ -62,9 +59,6 @@ func (c *Cluster) PrepareBackup(ctx context.Context, snapshotPath string) error 
 	var backupServer *hosts.Host
 	backupImage := c.getBackupImage()
 	var errors []error
-	if !util.IsRancherBackupSupported(c.SystemImages.Alpine) {
-		log.Warnf(ctx, "Auto local backup sync is not supported in `%s`. Using `%s` instead.", c.SystemImages.Alpine, backupImage)
-	}
 	if c.Services.Etcd.BackupConfig == nil || // legacy rke local backup
 		(c.Services.Etcd.BackupConfig != nil && IsLocalSnapshot(snapshotPath)) { // rancher local backup and snapshot name indicates a local snapshot
 		// stop etcd on all etcd nodes, we need this because we start the backup server on the same port
@@ -145,9 +139,6 @@ func (c *Cluster) RestoreEtcdSnapshot(ctx context.Context, snapshotPath string) 
 
 func (c *Cluster) RemoveEtcdSnapshot(ctx context.Context, snapshotName string) error {
 	backupImage := c.getBackupImage()
-	if !util.IsRancherBackupSupported(c.SystemImages.Alpine) {
-		log.Warnf(ctx, "Auto local backup sync is not supported in `%s`. Using `%s` instead.", c.SystemImages.Alpine, backupImage)
-	}
 	for _, host := range c.EtcdHosts {
 		if err := services.RunEtcdSnapshotRemove(ctx, host, c.PrivateRegistriesMap, backupImage, snapshotName, true, c.Services.Etcd); err != nil {
 			return err
@@ -179,10 +170,7 @@ func (c *Cluster) etcdSnapshotChecksum(ctx context.Context, snapshotPath string)
 }
 
 func (c *Cluster) getBackupImage() string {
-	if util.IsRancherBackupSupported(c.SystemImages.Alpine) {
-		return c.SystemImages.Alpine
-	}
-	return util.GetDefaultRKETools()
+	return util.DefaultRKETools
 }
 
 func IsLocalSnapshot(name string) bool {

--- a/services/etcd.go
+++ b/services/etcd.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rancher/rke/log"
 	"github.com/rancher/rke/pki"
 	"github.com/rancher/rke/util"
-	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/util/cert"
@@ -53,10 +53,10 @@ func RunEtcdPlane(
 			return err
 		}
 		if *es.Snapshot == true {
-			if err := RunEtcdSnapshotSave(ctx, host, prsMap, alpineImage, EtcdSnapshotContainerName, false, es); err != nil {
+			if err := RunEtcdSnapshotSave(ctx, host, prsMap, util.DefaultRKETools, EtcdSnapshotContainerName, false, es); err != nil {
 				return err
 			}
-			if err := pki.SaveBackupBundleOnHost(ctx, host, alpineImage, EtcdSnapshotPath, prsMap); err != nil {
+			if err := pki.SaveBackupBundleOnHost(ctx, host, util.DefaultRKETools, EtcdSnapshotPath, prsMap); err != nil {
 				return err
 			}
 		} else {
@@ -273,9 +273,6 @@ func RunEtcdSnapshotSave(ctx context.Context, etcdHost *hosts.Host, prsMap map[s
 	log.Infof(ctx, "[etcd] Saving snapshot [%s] on host [%s]", name, etcdHost.Address)
 	backupCmd := "etcd-backup"
 	restartPolicy := "always"
-	if !util.IsRancherBackupSupported(etcdSnapshotImage) {
-		backupCmd = "rolling-backup"
-	}
 	imageCfg := &container.Config{
 		Cmd: []string{
 			"/opt/rke-tools/rke-etcd-backup",

--- a/util/util.go
+++ b/util/util.go
@@ -8,15 +8,13 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	ref "github.com/docker/distribution/reference"
-	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/sirupsen/logrus"
 )
 
 const (
 	WorkerThreads = 50
-	// SupportedSyncToolsVersion this should be kept at the latest version of rke released with
-	// rancher 2.2.0.
-	SupportedSyncToolsVersion = "0.1.25"
+
+	DefaultRKETools = "rancher/rke-tools:v0.1.30"
 )
 
 func StrToSemVer(version string) (*semver.Version, error) {
@@ -68,34 +66,6 @@ func IsSymlink(file string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
-}
-
-func GetDefaultRKETools() string {
-	return v3.AllK8sVersions[v3.DefaultK8s].Alpine
-}
-
-// IsRancherBackupSupported  with rancher 2.2.0 and rke 0.2.0, etcdbackup was completely refactored
-// and the interface for the rke-tools backup command changed significantly.
-// This function is used to check the the release rke-tools version to choose
-// between the new backup or the legacy backup code paths.
-// The released version of rke-tools should be set in the const SupportedSyncToolsVersion
-func IsRancherBackupSupported(image string) bool {
-	v := strings.Split(image, ":")
-	last := v[len(v)-1]
-
-	sv, err := StrToSemVer(last)
-	if err != nil {
-		return false
-	}
-
-	supported, err := StrToSemVer(SupportedSyncToolsVersion)
-	if err != nil {
-		return false
-	}
-	if sv.LessThan(*supported) {
-		return false
-	}
-	return true
 }
 
 func GetTagMajorVersion(tag string) string {


### PR DESCRIPTION
we can remove dependency of etcd snapshot actions on rke-tools and just use the latest version 