### PR TITLE
duplicting nodes based on address and port

### DIFF
--- a/cluster/validation.go
+++ b/cluster/validation.go
@@ -183,7 +183,7 @@ func validateDuplicateNodes(c *Cluster) error {
 			if i == j {
 				continue
 			}
-			if c.Nodes[i].Address == c.Nodes[j].Address {
+			if c.Nodes[i].Address == c.Nodes[j].Address && c.Nodes[i].Port == c.Nodes[j].Port {
 				return fmt.Errorf("Cluster can't have duplicate node: %s", c.Nodes[i].Address)
 			}
 			if c.Nodes[i].HostnameOverride == c.Nodes[j].HostnameOverride {


### PR DESCRIPTION
Identifying duplicated nodes only based on the **addresses** is not really interesting because of some situation that I was dealt with that and others makes a problem (check this issue #997 and also some issue about that in **rancher** repository). In addition, I tried to do what people said in those issues I refer but it's not working at all and these solutions try to remove the question not responding it well! so the best solution that I think is to check both **address** and **port** 