### PR TITLE
Fix always returning the default network template

### DIFF
--- a/cluster/network.go
+++ b/cluster/network.go
@@ -247,9 +247,9 @@ func (c *Cluster) getNetworkPluginManifest(pluginConfig map[string]interface{}) 
 	case FlannelNetworkPlugin:
 		return templates.CompileTemplateFromMap(templates.FlannelTemplate, pluginConfig)
 	case CalicoNetworkPlugin:
-		return templates.CompileTemplateFromMap(templates.GetVersionedTemplates(CalicoNetworkPlugin, c.Version), pluginConfig)
+		return templates.CompileTemplateFromMap(templates.GetVersionedTemplates(CalicoNetworkPlugin, util.GetTagMajorVersion(c.Version)), pluginConfig)
 	case CanalNetworkPlugin:
-		return templates.CompileTemplateFromMap(templates.GetVersionedTemplates(CanalNetworkPlugin, c.Version), pluginConfig)
+		return templates.CompileTemplateFromMap(templates.GetVersionedTemplates(CanalNetworkPlugin, util.GetTagMajorVersion(c.Version)), pluginConfig)
 	case WeaveNetworkPlugin:
 		return templates.CompileTemplateFromMap(templates.WeaveTemplate, pluginConfig)
 	default:


### PR DESCRIPTION
templates/calico.go and templates/canal.go all have TemplateV112 and TemplateV113 definitions, but it always returns the default templateV112. On Rancher 2.2.4, this causes the Custom cluster calico-node always fails with readiness/liveness probe. Currently the workaround is that user can switch the readiness probe way from the command method /bin/calico-node -felix-ready -bird-ready to the http request method via :9099/readiness.