### PR TITLE
[WIP]Add taints support for node

### DIFF
--- a/hosts/taint_test.go
+++ b/hosts/taint_test.go
@@ -1,0 +1,101 @@
+package hosts
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"k8s.io/api/core/v1"
+)
+
+var testTaint = v1.Taint{
+	Key:    "key",
+	Effect: v1.TaintEffectNoSchedule,
+}
+
+var testCases = []struct {
+	toAdd       []string
+	toDel       []string
+	currentHost *Host
+	specHost    *Host
+}{
+	{
+		toAdd: []string{},
+		toDel: []string{},
+		currentHost: &Host{
+			RKEConfigNode: v3.RKEConfigNode{},
+		},
+		specHost: &Host{
+			RKEConfigNode: v3.RKEConfigNode{},
+		},
+	},
+	{
+		toAdd: []string{},
+		toDel: []string{GetTaintString(testTaint)},
+		currentHost: &Host{
+			RKEConfigNode: v3.RKEConfigNode{
+				Taints: []v1.Taint{
+					testTaint,
+				},
+			},
+		},
+		specHost: &Host{
+			RKEConfigNode: v3.RKEConfigNode{
+				Taints: []v1.Taint{},
+			},
+		},
+	},
+	{
+		toAdd: []string{GetTaintString(testTaint)},
+		toDel: []string{},
+		currentHost: &Host{
+			RKEConfigNode: v3.RKEConfigNode{
+				Taints: []v1.Taint{},
+			},
+		},
+		specHost: &Host{
+			RKEConfigNode: v3.RKEConfigNode{
+				Taints: []v1.Taint{
+					testTaint,
+				},
+			},
+		},
+	},
+	{
+		toAdd: []string{},
+		toDel: []string{},
+		currentHost: &Host{
+			RKEConfigNode: v3.RKEConfigNode{
+				Taints: []v1.Taint{
+					testTaint,
+				},
+			},
+		},
+		specHost: &Host{
+			RKEConfigNode: v3.RKEConfigNode{
+				Taints: []v1.Taint{
+					testTaint,
+				},
+			},
+		},
+	},
+}
+
+func Test_HostDiffTaints(t *testing.T) {
+	for _, testCase := range testCases {
+		toAdd, toDel := GetHostDiffTaints(testCase.currentHost, testCase.specHost)
+		assertEqual(t, toAdd, testCase.toAdd, fmt.Sprintf("taints to add are not as expected, test case: %v", testCase))
+		assertEqual(t, toDel, testCase.toDel, fmt.Sprintf("taints to delete are not as expected, test case: %v", testCase))
+	}
+}
+
+func assertEqual(t *testing.T, a interface{}, b interface{}, message string) {
+	if reflect.DeepEqual(a, b) {
+		return
+	}
+	if len(message) == 0 {
+		message = fmt.Sprintf("%v != %v", a, b)
+	}
+	t.Fatal(message)
+}

--- a/services/workerplane.go
+++ b/services/workerplane.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/rke/pki"
 	"github.com/rancher/rke/util"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -56,6 +57,13 @@ func doDeployWorkerPlaneHost(ctx context.Context, host *hosts.Host, localConnDia
 		if host.IsControl {
 			// Add unschedulable taint
 			host.ToAddTaints = append(host.ToAddTaints, unschedulableControlTaint)
+		}
+		if len(host.RKEConfigNode.Taints) != 0 {
+			logrus.Warnf("non-worker host %s has taints, going to ignore them", host.Address)
+		}
+	} else {
+		for _, taint := range host.RKEConfigNode.Taints {
+			host.ToAddTaints = append(host.ToAddTaints, hosts.GetTaintString(taint))
 		}
 	}
 	return doDeployWorkerPlane(ctx, host, localConnDialerFactory, prsMap, processMap, certMap, alpineImage)

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,4 +28,4 @@ github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0e
 github.com/mattn/go-colorable            efa589957cd060542a26d2dd7832fd6a6c6c3ade
 github.com/mattn/go-isatty               6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 github.com/rancher/norman                f5744043a6fb81330ee78e4f7a0f04d0ef65c9f1
-github.com/rancher/types                 1ce8b01468b32607cf132c1225d5a9719acd60f8
+github.com/rancher/types                 56aa2bbf3f0e3fae6f5824041da3ca7973c72062 https://github.com/orangedeng/types

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -95,6 +95,7 @@ type ClusterSpecBase struct {
 	EnableNetworkPolicy                  *bool                          `json:"enableNetworkPolicy" norman:"default=false"`
 	EnableClusterAlerting                bool                           `json:"enableClusterAlerting" norman:"default=false"`
 	EnableClusterMonitoring              bool                           `json:"enableClusterMonitoring" norman:"default=false"`
+	WindowsPreferedCluster               bool                           `json:"windowsPreferedCluster" norman:"default=false,noupdate"`
 	LocalClusterAuthEndpoint             LocalClusterAuthEndpoint       `json:"localClusterAuthEndpoint,omitempty"`
 }
 

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/machine_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/machine_types.go
@@ -152,6 +152,8 @@ type NodePoolSpec struct {
 
 	DisplayName string `json:"displayName"`
 	ClusterName string `json:"clusterName,omitempty" norman:"type=reference[cluster],noupdate,required"`
+
+	Taints []v1.Taint `yaml:"taints" json:"taints,omitempty"`
 }
 
 type NodePoolStatus struct {
@@ -172,6 +174,7 @@ type CustomConfig struct {
 	// SSH Certificate
 	SSHCert string            `yaml:"ssh_cert" json:"sshCert,omitempty"`
 	Label   map[string]string `yaml:"label" json:"label,omitempty"`
+	Taints  []string          `yaml:"taints" json:"taints,omitempty"`
 }
 
 type NodeSpec struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
@@ -1,5 +1,7 @@
 package v3
 
+import v1 "k8s.io/api/core/v1"
+
 type RancherKubernetesEngineConfig struct {
 	// Kubernetes nodes
 	Nodes []RKEConfigNode `yaml:"nodes" json:"nodes,omitempty"`
@@ -167,6 +169,8 @@ type RKEConfigNode struct {
 	SSHCertPath string `yaml:"ssh_cert_path" json:"sshCertPath,omitempty"`
 	// Node Labels
 	Labels map[string]string `yaml:"labels" json:"labels,omitempty"`
+	// Node Taints
+	Taints []v1.Taint `yaml:"taints" json:"taints,omitempty"`
 }
 
 type RKEConfigServices struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -2519,6 +2519,11 @@ func (in *CustomConfig) DeepCopyInto(out *CustomConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.Taints != nil {
+		in, out := &in.Taints, &out.Taints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -5434,6 +5439,13 @@ func (in *NodePoolSpec) DeepCopyInto(out *NodePoolSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Taints != nil {
+		in, out := &in.Taints, &out.Taints
+		*out = make([]v1.Taint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 
@@ -7517,6 +7529,13 @@ func (in *RKEConfigNode) DeepCopyInto(out *RKEConfigNode) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.Taints != nil {
+		in, out := &in.Taints, &out.Taints
+		*out = make([]v1.Taint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	return


### PR DESCRIPTION
The taints configuration is only validated in worker nodes.
If the user configure taints in non-worker nodes, RKE will have
warning logs.

Related issue:
https://github.com/rancher/rancher/issues/20805
https://github.com/rancher/rancher/issues/13972