### PR TITLE
NodeSelector should specify string explicitly

### DIFF
--- a/templates/coredns.go
+++ b/templates/coredns.go
@@ -121,7 +121,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       {{ range $k, $v := .NodeSelector }}
-        {{ $k }}: {{ $v }}
+        {{ $k }}: "{{ $v }}"
       {{ end }}
       containers:
       - name: coredns

--- a/templates/kubedns.go
+++ b/templates/kubedns.go
@@ -124,7 +124,7 @@ spec:
     spec:
       nodeSelector:
       {{ range $k, $v := .NodeSelector }}
-        {{ $k }}: {{ $v }}
+        {{ $k }}: "{{ $v }}"
       {{ end }}
       affinity:
         podAntiAffinity:

--- a/templates/nginx-ingress.go
+++ b/templates/nginx-ingress.go
@@ -188,7 +188,7 @@ spec:
       hostNetwork: true
       nodeSelector:
       {{ range $k, $v := .NodeSelector }}
-        {{ $k }}: {{ $v }}
+        {{ $k }}: "{{ $v }}"
       {{ end }}
       {{if eq .RBACConfig "rbac"}}
       serviceAccountName: nginx-ingress-serviceaccount


### PR DESCRIPTION
#1437

Kubernetes doesn't accept any other value but string in nodeSelector,
but if we specified ambiguous value like true, it's treated as a
non-string like bool and then failed to create resource because of type
mis-match, that's why we should make value of nodeSelector enclosed by
double quotations to ensure value is always string