### PR TITLE
generate correct default rketools

### DIFF
--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"regexp"
 
 	"github.com/rancher/rke/docker"
@@ -170,7 +171,12 @@ func (c *Cluster) etcdSnapshotChecksum(ctx context.Context, snapshotPath string)
 }
 
 func (c *Cluster) getBackupImage() string {
-	return util.DefaultRKETools
+	rkeToolsImage, err := util.GetDefaultRKETools(c.SystemImages.Alpine)
+	if err != nil {
+		logrus.Errorf("[etcd] error getting backup image %v", err)
+		return ""
+	}
+	return rkeToolsImage
 }
 
 func IsLocalSnapshot(name string) bool {

--- a/services/etcd.go
+++ b/services/etcd.go
@@ -54,10 +54,14 @@ func RunEtcdPlane(
 			return err
 		}
 		if *es.Snapshot == true {
-			if err := RunEtcdSnapshotSave(ctx, host, prsMap, util.DefaultRKETools, EtcdSnapshotContainerName, false, es); err != nil {
+			rkeToolsImage, err := util.GetDefaultRKETools(alpineImage)
+			if err != nil {
 				return err
 			}
-			if err := pki.SaveBackupBundleOnHost(ctx, host, util.DefaultRKETools, EtcdSnapshotPath, prsMap); err != nil {
+			if err := RunEtcdSnapshotSave(ctx, host, prsMap, rkeToolsImage, EtcdSnapshotContainerName, false, es); err != nil {
+				return err
+			}
+			if err := pki.SaveBackupBundleOnHost(ctx, host, rkeToolsImage, EtcdSnapshotPath, prsMap); err != nil {
 				return err
 			}
 		} else {

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"os"
 	"reflect"
 	"strings"
@@ -13,8 +14,6 @@ import (
 
 const (
 	WorkerThreads = 50
-
-	DefaultRKETools = "rancher/rke-tools:v0.1.34"
 )
 
 func StrToSemVer(version string) (*semver.Version, error) {
@@ -84,6 +83,19 @@ func IsFileExists(filePath string) (bool, error) {
 	} else {
 		return false, err
 	}
+}
+
+func GetDefaultRKETools(image string) (string, error) {
+	tag, err := GetImageTagFromImage(image)
+	if err != nil || tag == "" {
+		return "", fmt.Errorf("defaultRKETools: no tag %s", image)
+	}
+	toReplaceTag, err := GetImageTagFromImage(v3.AllK8sVersions[v3.DefaultK8s].Alpine)
+	if err != nil || toReplaceTag == "" {
+		return "", fmt.Errorf("defaultRKETools: no replace tag %s", v3.AllK8sVersions[v3.DefaultK8s].Alpine)
+	}
+	image = strings.Replace(image, tag, toReplaceTag, 1)
+	return image, nil
 }
 
 func GetImageTagFromImage(image string) (string, error) {


### PR DESCRIPTION
- use image path from c.systemImages which has the prefixed private registry info
- get default rke tool tag from the Default K8s, that ensures this rke-tools has always been pulled in (because it has been mentioned in rancher-images.txt)  

https://github.com/rancher/rke/issues/1472