### PR TITLE
generate correct default rketools

### DIFF
--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"regexp"
 
 	"github.com/rancher/rke/docker"
@@ -170,7 +171,12 @@ func (c *Cluster) etcdSnapshotChecksum(ctx context.Context, snapshotPath string)
 }
 
 func (c *Cluster) getBackupImage() string {
-	return util.DefaultRKETools
+	rkeToolsImage, err := util.GetDefaultRKETools(c.SystemImages.Alpine)
+	if err != nil {
+		logrus.Errorf("[etcd] error getting backup image %v", err)
+		return ""
+	}
+	return rkeToolsImage
 }
 
 func IsLocalSnapshot(name string) bool {

--- a/services/etcd.go
+++ b/services/etcd.go
@@ -54,10 +54,14 @@ func RunEtcdPlane(
 			return err
 		}
 		if *es.Snapshot == true {
-			if err := RunEtcdSnapshotSave(ctx, host, prsMap, util.DefaultRKETools, EtcdSnapshotContainerName, false, es); err != nil {
+			rkeToolsImage, err := util.GetDefaultRKETools(alpineImage)
+			if err != nil {
 				return err
 			}
-			if err := pki.SaveBackupBundleOnHost(ctx, host, util.DefaultRKETools, EtcdSnapshotPath, prsMap); err != nil {
+			if err := RunEtcdSnapshotSave(ctx, host, prsMap, rkeToolsImage, EtcdSnapshotContainerName, false, es); err != nil {
+				return err
+			}
+			if err := pki.SaveBackupBundleOnHost(ctx, host, rkeToolsImage, EtcdSnapshotPath, prsMap); err != nil {
 				return err
 			}
 		} else {

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/rancher/rke/metadata"
 	"os"
 	"reflect"
 	"strings"
@@ -13,8 +14,6 @@ import (
 
 const (
 	WorkerThreads = 50
-
-	DefaultRKETools = "rancher/rke-tools:v0.1.35"
 )
 
 func StrToSemVer(version string) (*semver.Version, error) {
@@ -84,6 +83,20 @@ func IsFileExists(filePath string) (bool, error) {
 	} else {
 		return false, err
 	}
+}
+
+func GetDefaultRKETools(image string) (string, error) {
+	tag, err := GetImageTagFromImage(image)
+	if err != nil || tag == "" {
+		return "", fmt.Errorf("defaultRKETools: no tag %s", image)
+	}
+	defaultImage := metadata.K8sVersionToRKESystemImages[metadata.DefaultK8sVersion].Alpine
+	toReplaceTag, err := GetImageTagFromImage(defaultImage)
+	if err != nil || toReplaceTag == "" {
+		return "", fmt.Errorf("defaultRKETools: no replace tag %s", defaultImage)
+	}
+	image = strings.Replace(image, tag, toReplaceTag, 1)
+	return image, nil
 }
 
 func GetImageTagFromImage(image string) (string, error) {


### PR DESCRIPTION
always use rke's default k8s's rke-tools, even if rancher's default k8s
changes. This is based on assumption that change in rke-tools would also
require a new rke version.