### PR TITLE
Do not parse docker version when validation is disabled

### DIFF
--- a/hosts/tunnel.go
+++ b/hosts/tunnel.go
@@ -65,6 +65,9 @@ func checkDockerVersion(ctx context.Context, h *Host, clusterVersion string) err
 		return fmt.Errorf("Can't retrieve Docker Info: %v", err)
 	}
 	logrus.Debugf("Docker Info found: %#v", info)
+	if h.IgnoreDockerVersion {
+		return nil
+	}
 	h.DockerInfo = info
 	K8sSemVer, err := util.StrToSemVer(clusterVersion)
 	if err != nil {
@@ -76,7 +79,7 @@ func checkDockerVersion(ctx context.Context, h *Host, clusterVersion string) err
 		return fmt.Errorf("Error while determining supported Docker version [%s]: %v", info.ServerVersion, err)
 	}
 
-	if !isvalid && !h.IgnoreDockerVersion {
+	if !isvalid {
 		return fmt.Errorf("Unsupported Docker version found [%s], supported versions are %v", info.ServerVersion, metadata.K8sVersionToDockerVersions[K8sVersion])
 	} else if !isvalid {
 		log.Warnf(ctx, "Unsupported Docker version found [%s], supported versions are %v", info.ServerVersion, metadata.K8sVersionToDockerVersions[K8sVersion])

--- a/hosts/tunnel.go
+++ b/hosts/tunnel.go
@@ -65,10 +65,10 @@ func checkDockerVersion(ctx context.Context, h *Host, clusterVersion string) err
 		return fmt.Errorf("Can't retrieve Docker Info: %v", err)
 	}
 	logrus.Debugf("Docker Info found: %#v", info)
+	h.DockerInfo = info
 	if h.IgnoreDockerVersion {
 		return nil
 	}
-	h.DockerInfo = info
 	K8sSemVer, err := util.StrToSemVer(clusterVersion)
 	if err != nil {
 		return fmt.Errorf("Error while parsing cluster version [%s]: %v", clusterVersion, err)
@@ -81,8 +81,6 @@ func checkDockerVersion(ctx context.Context, h *Host, clusterVersion string) err
 
 	if !isvalid {
 		return fmt.Errorf("Unsupported Docker version found [%s], supported versions are %v", info.ServerVersion, metadata.K8sVersionToDockerVersions[K8sVersion])
-	} else if !isvalid {
-		log.Warnf(ctx, "Unsupported Docker version found [%s], supported versions are %v", info.ServerVersion, metadata.K8sVersionToDockerVersions[K8sVersion])
 	}
 	return nil
 }


### PR DESCRIPTION
When IgnoreDockerVersion is set, do not try to parse its version number
Still retrieve docker info to check check fi docker is reachable

https://github.com/rancher/rke/issues/1502