### PR TITLE
Support node taints configuration

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -363,6 +363,9 @@ func (c *Cluster) SyncLabelsAndTaints(ctx context.Context, currentCluster *Clust
 		}
 	}
 
+	// sync node taints. Add or remove taints from hosts
+	syncTaints(ctx, currentCluster, c)
+
 	if len(c.ControlPlaneHosts) > 0 {
 		log.Infof(ctx, "[sync] Syncing nodes Labels and Taints")
 		k8sClient, err := k8s.NewClient(c.LocalKubeConfigPath, c.K8sWrapTransport)


### PR DESCRIPTION
**Problem:**
We can not set node taints in RKE node config.

**Solution:**
Sync taints from config in `SyncLabelsAndTaints` function

Related issue:
https://github.com/rancher/rancher/issues/13972