### PR TITLE
Use correct labels to delete calico pods

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -495,10 +495,9 @@ func RestartClusterPods(ctx context.Context, kubeCluster *Cluster) error {
 		return fmt.Errorf("Failed to initialize new kubernetes client: %v", err)
 	}
 	labelsList := []string{
-		fmt.Sprintf("%s=%s", KubeAppLabel, CalicoNetworkPlugin),
 		fmt.Sprintf("%s=%s", KubeAppLabel, FlannelNetworkPlugin),
 		fmt.Sprintf("%s=%s", KubeAppLabel, CanalNetworkPlugin),
-		fmt.Sprintf("%s=%s", NameLabel, WeaveNetowrkAppName),
+		fmt.Sprintf("%s=%s", NameLabel, WeaveNetworkAppName),
 		fmt.Sprintf("%s=%s", AppLabel, NginxIngressAddonAppName),
 		fmt.Sprintf("%s=%s", KubeAppLabel, DefaultMonitoringProvider),
 		fmt.Sprintf("%s=%s", KubeAppLabel, KubeDNSAddonAppName),
@@ -506,6 +505,9 @@ func RestartClusterPods(ctx context.Context, kubeCluster *Cluster) error {
 		fmt.Sprintf("%s=%s", KubeAppLabel, CoreDNSAutoscalerAppName),
 		fmt.Sprintf("%s=%s", AppLabel, KubeAPIAuthAppName),
 		fmt.Sprintf("%s=%s", AppLabel, CattleClusterAgentAppName),
+	}
+	for _, calicoLabel := range CalicoNetworkLabels {
+		labelsList = append(labelsList, fmt.Sprintf("%s=%s", KubeAppLabel, calicoLabel))
 	}
 	var errgrp errgroup.Group
 	labelQueue := util.GetObjectQueue(labelsList)

--- a/cluster/network.go
+++ b/cluster/network.go
@@ -52,8 +52,10 @@ const (
 	// FlannelBackendVxLanNetworkIdentify should be greater than or equal to 4096 if using VxLan mode in the cluster with Windows nodes
 	FlannelBackendVxLanNetworkIdentify = "flannel_backend_vni"
 
-	CalicoNetworkPlugin = "calico"
-	CalicoCloudProvider = "calico_cloud_provider"
+	CalicoNetworkPlugin   = "calico"
+	CalicoNodeLabel       = "calico-node"
+	CalicoControllerLabel = "calico-kube-controllers"
+	CalicoCloudProvider   = "calico_cloud_provider"
 
 	CanalNetworkPlugin      = "canal"
 	CanalIface              = "canal_iface"
@@ -64,7 +66,7 @@ const (
 	CanalFlannelBackendVxLanNetworkIdentify = "canal_flannel_backend_vni"
 
 	WeaveNetworkPlugin  = "weave"
-	WeaveNetowrkAppName = "weave-net"
+	WeaveNetworkAppName = "weave-net"
 	// List of map keys to be used with network templates
 
 	// EtcdEndpoints is the server address for Etcd, used by calico
@@ -122,6 +124,8 @@ var WorkerPortList = []string{
 var EtcdClientPortList = []string{
 	EtcdPort1,
 }
+
+var CalicoNetworkLabels = []string{CalicoNodeLabel, CalicoControllerLabel}
 
 func (c *Cluster) deployNetworkPlugin(ctx context.Context, data map[string]interface{}) error {
 	log.Infof(ctx, "[network] Setting up network plugin: %s", c.Network.Plugin)


### PR DESCRIPTION
Problem: Calico pods are not deleted when etcd snapshot restore is done.
Root cause: The wrong k8s-label was used to select calico pods for removal (`calico` vs `calico-node`)
Fix: Provide correct labels and loop over labels to delete calico pods.

https://github.com/rancher/rancher/issues/21490

Also fixes a typo: `WeaveNetowrkAppName` -> `WeaveNetworkAppName `