### PR TITLE
Make commonflags work with rke cert commands

### DIFF
--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -15,6 +15,30 @@ import (
 )
 
 func CertificateCommand() cli.Command {
+	rotateFlags := []cli.Flag{
+		cli.StringFlag{
+			Name:   "config",
+			Usage:  "Specify an alternate cluster YAML file",
+			Value:  pki.ClusterConfig,
+			EnvVar: "RKE_CONFIG",
+		},
+		cli.StringSliceFlag{
+			Name: "service",
+			Usage: fmt.Sprintf("Specify a k8s service to rotate certs, (allowed values: %s, %s, %s, %s, %s, %s)",
+				services.KubeAPIContainerName,
+				services.KubeControllerContainerName,
+				services.SchedulerContainerName,
+				services.KubeletContainerName,
+				services.KubeproxyContainerName,
+				services.EtcdContainerName,
+			),
+		},
+		cli.BoolFlag{
+			Name:  "rotate-ca",
+			Usage: "Rotate all certificates including CA certs",
+		},
+	}
+	rotateFlags = append(rotateFlags, commonFlags...)
 	return cli.Command{
 		Name:  "cert",
 		Usage: "Certificates management for RKE cluster",
@@ -23,29 +47,7 @@ func CertificateCommand() cli.Command {
 				Name:   "rotate",
 				Usage:  "Rotate RKE cluster certificates",
 				Action: rotateRKECertificatesFromCli,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:   "config",
-						Usage:  "Specify an alternate cluster YAML file",
-						Value:  pki.ClusterConfig,
-						EnvVar: "RKE_CONFIG",
-					},
-					cli.StringSliceFlag{
-						Name: "service",
-						Usage: fmt.Sprintf("Specify a k8s service to rotate certs, (allowed values: %s, %s, %s, %s, %s, %s)",
-							services.KubeAPIContainerName,
-							services.KubeControllerContainerName,
-							services.SchedulerContainerName,
-							services.KubeletContainerName,
-							services.KubeproxyContainerName,
-							services.EtcdContainerName,
-						),
-					},
-					cli.BoolFlag{
-						Name:  "rotate-ca",
-						Usage: "Rotate all certificates including CA certs",
-					},
-				},
+				Flags:  rotateFlags,
 			},
 			cli.Command{
 				Name:   "generate-csr",


### PR DESCRIPTION
Problem: The flag `--ssh-agent-auth` cannot be used in `rke cert` commands.
Root cause: Common flags are not added to the `cert` subcommand
Fix: Add common flags to the `cert` subcommand

https://github.com/rancher/rke/issues/1479