### PR TITLE
Print version on start

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,14 +32,10 @@ func mainErr() error {
 	app.Version = VERSION
 	app.Usage = "Rancher Kubernetes Engine, an extremely simple, lightning fast Kubernetes installer that works everywhere"
 	app.Before = func(ctx *cli.Context) error {
+		logrus.Infof("%s version: %s", app.Name, app.Version)
 		if ctx.GlobalBool("debug") {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
-		if released.MatchString(app.Version) {
-			metadata.RKEVersion = app.Version
-			return nil
-		}
-		logrus.Warnf("This is not an officially supported version (%s) of RKE. Please download the latest official release at https://github.com/rancher/rke/releases/latest", app.Version)
 		// Print proxy related environment variables
 		for _, proxyEnvVar := range proxyEnvVars {
 			var err error
@@ -57,6 +53,11 @@ func mainErr() error {
 				logrus.Infof("Using proxy environment variable %s with value [%s]", key, value)
 			}
 		}
+		if released.MatchString(app.Version) {
+			metadata.RKEVersion = app.Version
+			return nil
+		}
+		logrus.Warnf("This is not an officially supported version (%s) of RKE. Please download the latest official release at https://github.com/rancher/rke/releases/latest", app.Version)
 		return nil
 	}
 	app.Author = "Rancher Labs, Inc."


### PR DESCRIPTION
https://github.com/rancher/rke/issues/1560

This also moves the released match to under the part where proxy environment variables are shown, as they were only shown on an unreleased version and the code was not reached when it was determined to be a released version (`return nil`)