### PR TITLE
Dont set withHost on Docker client

### DIFF
--- a/hosts/tunnel.go
+++ b/hosts/tunnel.go
@@ -36,7 +36,6 @@ func (h *Host) TunnelUp(ctx context.Context, dialerFactory DialerFactory, cluste
 	// set Docker client
 	logrus.Debugf("Connecting to Docker API for host [%s]", h.Address)
 	h.DClient, err = client.NewClientWithOpts(
-		client.WithHost("unix:///var/run/docker.sock"),
 		client.WithVersion(DockerAPIVersion),
 		client.WithHTTPClient(httpClient))
 	if err != nil {


### PR DESCRIPTION
Problem: Because of the unix socket reference, Windows breaks on rke up
Root cause: Vendor of docker/docker
Resolution: I was checking what was changed in vendor but it seems this setting is not used, as we configure Docker socket per host.

https://github.com/rancher/rke/issues/1189