### PR TITLE
Update apis for 1.16

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -227,7 +227,7 @@ func (c *Cluster) BuildKubeAPIProcess(host *hosts.Host, prefixPath string, svcOp
 	}
 
 	if c.Services.KubeAPI.PodSecurityPolicy {
-		CommandArgs["runtime-config"] = "extensions/v1beta1/podsecuritypolicy=true"
+		CommandArgs["runtime-config"] = "policy/v1beta1/podsecuritypolicy=true"
 		for _, optionName := range admissionControlOptionNames {
 			if _, ok := CommandArgs[optionName]; ok {
 				if c.Services.KubeAPI.AlwaysPullImages {

--- a/k8s/psp.go
+++ b/k8s/psp.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/policy/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 )
@@ -16,11 +16,11 @@ func UpdatePodSecurityPolicyFromYaml(k8sClient *kubernetes.Clientset, pspYaml st
 
 func updatePodSecurityPolicy(k8sClient *kubernetes.Clientset, p interface{}) error {
 	psp := p.(v1beta1.PodSecurityPolicy)
-	if _, err := k8sClient.ExtensionsV1beta1().PodSecurityPolicies().Create(&psp); err != nil {
+	if _, err := k8sClient.PolicyV1beta1().PodSecurityPolicies().Create(&psp); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return err
 		}
-		if _, err := k8sClient.ExtensionsV1beta1().PodSecurityPolicies().Update(&psp); err != nil {
+		if _, err := k8sClient.PolicyV1beta1().PodSecurityPolicies().Update(&psp); err != nil {
 			return err
 		}
 	}

--- a/templates/authz.go
+++ b/templates/authz.go
@@ -68,7 +68,7 @@ subjects:
   name: rke-job-deployer`
 
 	DefaultPodSecurityPolicy = `
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: default-psp


### PR DESCRIPTION
Pod security policy has moved from `extensions/v1beta1` to `policy/v1beta1` in 1.16
https://github.com/rancher/rancher/issues/22716