### PR TITLE
Provide IP for kube-proxy when cloudprovider = aws

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -47,6 +47,8 @@ const (
 	KubeletDockerConfigFileEnv = "RKE_KUBELET_DOCKER_FILE"
 	KubeletDockerConfigPath    = "/var/lib/kubelet/config.json"
 
+	AWSCloudProviderName = "aws"
+
 	// MaxEtcdOldEnvVersion The versions are maxed out for minor versions because -rancher1 suffix will cause semver to think its older, example: v1.15.0 > v1.15.0-rancher1
 	MaxEtcdOldEnvVersion = "v3.2.99"
 	MaxK8s115Version     = "v1.15"
@@ -583,6 +585,14 @@ func (c *Cluster) BuildKubeProxyProcess(host *hosts.Host, prefixPath string, svc
 				continue
 			}
 			CommandArgs[k] = v
+		}
+	}
+	// If cloudprovider is set to aws, set the bind address because the node will not be able to retrieve it's IP address because the nodename is set by AWS to internal DNS name
+	if c.CloudProvider.Name == AWSCloudProviderName {
+		if host.Address != host.InternalAddress {
+			CommandArgs["bind-address"] = host.InternalAddress
+		} else {
+			CommandArgs["bind-address"] = host.Address
 		}
 	}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/22814

If cloudprovider is set to aws, set the bind address because the node will not be able to retrieve it's IP address because the nodename is set by AWS to internal DNS name


Considerations taken:
- Scope it to 1.16 only: this would eliminate affecting existing setups, but that would introduce code to check for cluster version being 1.16 or higher and because its a dynamic variable (IP address is per node), it cant go in the generic getServiceOptions. This means code needs to be added in `cluster/plan.go` to scope for 1.16 or higher and this seems overly complex.
- Set address to `127.0.0.1` (which was what it autodetected to before 1.16): if we change the parameter, we can just set it to the proper value.
- A bigger plan for AWS cloudprovider issues is covered in https://github.com/rancher/rancher/issues/22849, where this fix seems appropriate to fix kube-proxy on 1.16.