### PR TITLE
WIP: feature/control-plane loadbalancer

### DIFF
--- a/cluster/certificates.go
+++ b/cluster/certificates.go
@@ -26,7 +26,11 @@ func SetUpAuthentication(ctx context.Context, kubeCluster, currentCluster *Clust
 
 func regenerateAPICertificate(c *Cluster, certificates map[string]pki.CertificatePKI) (map[string]pki.CertificatePKI, error) {
 	logrus.Debugf("[certificates] Regenerating kubeAPI certificate")
-	kubeAPIAltNames := pki.GetAltNames(c.ControlPlaneHosts, c.ClusterDomain, c.KubernetesServiceIP, c.Authentication.SANs)
+	SANs := c.Authentication.SANs
+	if len(c.ControlPlaneLoadBalancerAddress) > 0 {
+		SANs = append(SANs, c.ControlPlaneLoadBalancerAddress)
+	}
+	kubeAPIAltNames := pki.GetAltNames(c.ControlPlaneHosts, c.ControlPlaneLoadBalancerAddress, c.ClusterDomain, c.KubernetesServiceIP, SANs)
 	caCrt := certificates[pki.CACertName].Certificate
 	caKey := certificates[pki.CACertName].Key
 	kubeAPIKey := certificates[pki.KubeAPICertName].Key

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -569,3 +569,16 @@ func IsLegacyKubeAPI(ctx context.Context, kubeCluster *Cluster) (bool, error) {
 	}
 	return false, nil
 }
+
+// ControlPlaneAddresses returns the set of addresses which should be used to contact the kube-apiserver
+// If a control-plane loadbalancer is configured, it returns that address only.
+func (c *Cluster) ControlPlaneAddresses() []string {
+	if len(c.ControlPlaneLoadBalancerAddress) > 0 {
+		return []string{c.ControlPlaneLoadBalancerAddress}
+	}
+	cpAddresses := []string{}
+	for _, cpHost := range c.ControlPlaneHosts {
+		cpAddresses = append(cpAddresses, cpHost.Address)
+	}
+	return cpAddresses
+}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -242,12 +242,12 @@ func rebuildLocalAdminConfig(ctx context.Context, kubeCluster *Cluster) error {
 	var workingConfig, newConfig string
 	currentKubeConfig := kubeCluster.Certificates[pki.KubeAdminCertName]
 	caCrt := kubeCluster.Certificates[pki.CACertName].Certificate
-	for _, cpHost := range kubeCluster.ControlPlaneHosts {
+	for _, cpHostAddress := range kubeCluster.ControlPlaneAddresses() {
 		if (currentKubeConfig == pki.CertificatePKI{}) {
 			kubeCluster.Certificates = make(map[string]pki.CertificatePKI)
-			newConfig = getLocalAdminConfigWithNewAddress(kubeCluster.LocalKubeConfigPath, cpHost.Address, kubeCluster.ClusterName)
+			newConfig = getLocalAdminConfigWithNewAddress(kubeCluster.LocalKubeConfigPath, cpHostAddress, kubeCluster.ClusterName)
 		} else {
-			kubeURL := fmt.Sprintf("https://%s:6443", cpHost.Address)
+			kubeURL := fmt.Sprintf("https://%s:6443", cpHostAddress)
 			caData := string(cert.EncodeCertPEM(caCrt))
 			crtData := string(cert.EncodeCertPEM(currentKubeConfig.Certificate))
 			keyData := string(cert.EncodePrivateKeyPEM(currentKubeConfig.Key))
@@ -258,7 +258,7 @@ func rebuildLocalAdminConfig(ctx context.Context, kubeCluster *Cluster) error {
 		}
 		workingConfig = newConfig
 		if _, err := GetK8sVersion(kubeCluster.LocalKubeConfigPath, kubeCluster.K8sWrapTransport); err == nil {
-			log.Infof(ctx, "[reconcile] host [%s] is active master on the cluster", cpHost.Address)
+			log.Infof(ctx, "[reconcile] host [%s] is active master on the cluster", cpHostAddress)
 			break
 		}
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -36,6 +36,7 @@ type Cluster struct {
 	ConfigDir                        string
 	CloudConfigFile                  string
 	ControlPlaneHosts                []*hosts.Host
+	ControlPlaneLoadBalancerAddress  string
 	Certificates                     map[string]pki.CertificatePKI
 	CertificateDir                   string
 	ClusterDomain                    string
@@ -156,14 +157,15 @@ func ParseConfig(clusterFile string) (*v3.RancherKubernetesEngineConfig, error) 
 func InitClusterObject(ctx context.Context, rkeConfig *v3.RancherKubernetesEngineConfig, flags ExternalFlags) (*Cluster, error) {
 	// basic cluster object from rkeConfig
 	c := &Cluster{
-		AuthnStrategies:               make(map[string]bool),
-		RancherKubernetesEngineConfig: *rkeConfig,
-		ConfigPath:                    flags.ClusterFilePath,
-		ConfigDir:                     flags.ConfigDir,
-		DinD:                          flags.DinD,
-		CertificateDir:                flags.CertificateDir,
-		StateFilePath:                 GetStateFilePath(flags.ClusterFilePath, flags.ConfigDir),
-		PrivateRegistriesMap:          make(map[string]v3.PrivateRegistry),
+		AuthnStrategies:                 make(map[string]bool),
+		RancherKubernetesEngineConfig:   *rkeConfig,
+		ConfigPath:                      flags.ClusterFilePath,
+		ConfigDir:                       flags.ConfigDir,
+		DinD:                            flags.DinD,
+		CertificateDir:                  flags.CertificateDir,
+		StateFilePath:                   GetStateFilePath(flags.ClusterFilePath, flags.ConfigDir),
+		PrivateRegistriesMap:            make(map[string]v3.PrivateRegistry),
+		ControlPlaneLoadBalancerAddress: rkeConfig.ControlPlaneLoadBalancer,
 	}
 	if metadata.K8sVersionToRKESystemImages == nil {
 		metadata.InitMetadata(ctx)

--- a/cluster/network.go
+++ b/cluster/network.go
@@ -273,12 +273,12 @@ func (c *Cluster) getNetworkPluginManifest(pluginConfig, data map[string]interfa
 func (c *Cluster) CheckClusterPorts(ctx context.Context, currentCluster *Cluster) error {
 	if currentCluster != nil {
 		newEtcdHost := hosts.GetToAddHosts(currentCluster.EtcdHosts, c.EtcdHosts)
-		newControlPlanHosts := hosts.GetToAddHosts(currentCluster.ControlPlaneHosts, c.ControlPlaneHosts)
+		newControlPlaneHosts := hosts.GetToAddHosts(currentCluster.ControlPlaneHosts, c.ControlPlaneHosts)
 		newWorkerHosts := hosts.GetToAddHosts(currentCluster.WorkerHosts, c.WorkerHosts)
 
 		if len(newEtcdHost) == 0 &&
 			len(newWorkerHosts) == 0 &&
-			len(newControlPlanHosts) == 0 {
+			len(newControlPlaneHosts) == 0 {
 			log.Infof(ctx, "[network] No hosts added existing cluster, skipping port check")
 			return nil
 		}

--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -677,10 +677,14 @@ func (c *Cluster) BuildProxyProcess(host *hosts.Host, prefixPath string) v3.Proc
 	}
 
 	nginxProxyEnv := ""
-	for i, host := range c.ControlPlaneHosts {
-		nginxProxyEnv += fmt.Sprintf("%s", host.InternalAddress)
-		if i < (len(c.ControlPlaneHosts) - 1) {
-			nginxProxyEnv += ","
+	if len(c.ControlPlaneLoadBalancer) > 0 {
+		nginxProxyEnv = c.ControlPlaneLoadBalancer
+	} else {
+		for i, host := range c.ControlPlaneHosts {
+			nginxProxyEnv += fmt.Sprintf("%s", host.InternalAddress)
+			if i < (len(c.ControlPlaneHosts) - 1) {
+				nginxProxyEnv += ","
+			}
 		}
 	}
 	Env := []string{fmt.Sprintf("%s=%s", services.NginxProxyEnvName, nginxProxyEnv)}

--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -155,7 +155,7 @@ func rebuildClusterWithRotatedCertificates(ctx context.Context,
 	if err := cluster.SetUpAuthentication(ctx, kubeCluster, nil, clusterState); err != nil {
 		return APIURL, caCrt, clientCert, clientKey, nil, err
 	}
-	APIURL = fmt.Sprintf("https://" + kubeCluster.ControlPlaneHosts[0].Address + ":6443")
+	APIURL = fmt.Sprintf("https://%s:6443", kubeCluster.ControlPlaneHosts[0].Address)
 	clientCert = string(cert.EncodeCertPEM(kubeCluster.Certificates[pki.KubeAdminCertName].Certificate))
 	clientKey = string(cert.EncodePrivateKeyPEM(kubeCluster.Certificates[pki.KubeAdminCertName].Key))
 	caCrt = string(cert.EncodeCertPEM(kubeCluster.Certificates[pki.CACertName].Certificate))

--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -155,7 +155,7 @@ func rebuildClusterWithRotatedCertificates(ctx context.Context,
 	if err := cluster.SetUpAuthentication(ctx, kubeCluster, nil, clusterState); err != nil {
 		return APIURL, caCrt, clientCert, clientKey, nil, err
 	}
-	APIURL = fmt.Sprintf("https://%s:6443", kubeCluster.ControlPlaneHosts[0].Address)
+	APIURL = fmt.Sprintf("https://%s:6443", kubeCluster.ControlPlaneAddresses()[0])
 	clientCert = string(cert.EncodeCertPEM(kubeCluster.Certificates[pki.KubeAdminCertName].Certificate))
 	clientKey = string(cert.EncodePrivateKeyPEM(kubeCluster.Certificates[pki.KubeAdminCertName].Key))
 	caCrt = string(cert.EncodeCertPEM(kubeCluster.Certificates[pki.CACertName].Certificate))

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -120,7 +120,7 @@ func ClusterUp(ctx context.Context, dialersOptions hosts.DialersOptions, flags c
 		return APIURL, caCrt, clientCert, clientKey, nil, err
 	}
 	if len(kubeCluster.ControlPlaneHosts) > 0 {
-		APIURL = fmt.Sprintf("https://%v:%v", kubeCluster.ControlPlaneHosts[0].Address, "6443")
+		APIURL = fmt.Sprintf("https://%s:6443", kubeCluster.ControlPlaneHosts[0].Address)
 	}
 	clientCert = string(cert.EncodeCertPEM(kubeCluster.Certificates[pki.KubeAdminCertName].Certificate))
 	clientKey = string(cert.EncodePrivateKeyPEM(kubeCluster.Certificates[pki.KubeAdminCertName].Key))
@@ -138,7 +138,7 @@ func ClusterUp(ctx context.Context, dialersOptions hosts.DialersOptions, flags c
 	}
 	// update APIURL after reconcile
 	if len(kubeCluster.ControlPlaneHosts) > 0 {
-		APIURL = fmt.Sprintf("https://%v:%v", kubeCluster.ControlPlaneHosts[0].Address, "6443")
+		APIURL = fmt.Sprintf("https://%s:6443", kubeCluster.ControlPlaneHosts[0].Address)
 	}
 
 	if err := kubeCluster.PrePullK8sImages(ctx); err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -120,7 +120,7 @@ func ClusterUp(ctx context.Context, dialersOptions hosts.DialersOptions, flags c
 		return APIURL, caCrt, clientCert, clientKey, nil, err
 	}
 	if len(kubeCluster.ControlPlaneHosts) > 0 {
-		APIURL = fmt.Sprintf("https://" + kubeCluster.ControlPlaneHosts[0].Address + ":6443")
+		APIURL = fmt.Sprintf("https://%v:%v", kubeCluster.ControlPlaneHosts[0].Address, "6443")
 	}
 	clientCert = string(cert.EncodeCertPEM(kubeCluster.Certificates[pki.KubeAdminCertName].Certificate))
 	clientKey = string(cert.EncodePrivateKeyPEM(kubeCluster.Certificates[pki.KubeAdminCertName].Key))
@@ -138,7 +138,7 @@ func ClusterUp(ctx context.Context, dialersOptions hosts.DialersOptions, flags c
 	}
 	// update APIURL after reconcile
 	if len(kubeCluster.ControlPlaneHosts) > 0 {
-		APIURL = fmt.Sprintf("https://" + kubeCluster.ControlPlaneHosts[0].Address + ":6443")
+		APIURL = fmt.Sprintf("https://%v:%v", kubeCluster.ControlPlaneHosts[0].Address, "6443")
 	}
 
 	if err := kubeCluster.PrePullK8sImages(ctx); err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -120,7 +120,7 @@ func ClusterUp(ctx context.Context, dialersOptions hosts.DialersOptions, flags c
 		return APIURL, caCrt, clientCert, clientKey, nil, err
 	}
 	if len(kubeCluster.ControlPlaneHosts) > 0 {
-		APIURL = fmt.Sprintf("https://%s:6443", kubeCluster.ControlPlaneHosts[0].Address)
+		APIURL = fmt.Sprintf("https://%s:6443", kubeCluster.ControlPlaneAddresses()[0])
 	}
 	clientCert = string(cert.EncodeCertPEM(kubeCluster.Certificates[pki.KubeAdminCertName].Certificate))
 	clientKey = string(cert.EncodePrivateKeyPEM(kubeCluster.Certificates[pki.KubeAdminCertName].Key))
@@ -138,7 +138,7 @@ func ClusterUp(ctx context.Context, dialersOptions hosts.DialersOptions, flags c
 	}
 	// update APIURL after reconcile
 	if len(kubeCluster.ControlPlaneHosts) > 0 {
-		APIURL = fmt.Sprintf("https://%s:6443", kubeCluster.ControlPlaneHosts[0].Address)
+		APIURL = fmt.Sprintf("https://%s:6443", kubeCluster.ControlPlaneAddresses()[0])
 	}
 
 	if err := kubeCluster.PrePullK8sImages(ctx); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -54,3 +54,5 @@ require (
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190805182715-88a2adca7e76+incompatible
 )
+
+replace github.com/rancher/types => github.com/rowanj/types v0.0.0-20190925034120-e6daf9d60882

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ github.com/rancher/types v0.0.0-20190827214052-704648244586 h1:4GEIdOsBFhWjlURz2
 github.com/rancher/types v0.0.0-20190827214052-704648244586/go.mod h1:9L7VLTwNVt7vJYwP/7xrQ4tWghDQ+zl9//RTqRjGxes=
 github.com/rancher/wrangler v0.1.5 h1:HiXOeP6Kci2DK+e04D1g6INT77xAYpAr54zmTTe0Spk=
 github.com/rancher/wrangler v0.1.5/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
+github.com/rowanj/types v0.0.0-20190925034120-e6daf9d60882 h1:AonMLX2YJQZg7ijx6vJJCCbC97NgfewBzeVFi40b1oU=
+github.com/rowanj/types v0.0.0-20190925034120-e6daf9d60882/go.mod h1:9L7VLTwNVt7vJYwP/7xrQ4tWghDQ+zl9//RTqRjGxes=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/pki/util.go
+++ b/pki/util.go
@@ -720,9 +720,13 @@ func ValidateBundleContent(rkeConfig *v3.RancherKubernetesEngineConfig, certBund
 	cpHosts := hosts.NodesToHosts(rkeConfig.Nodes, controlRole)
 	localKubeConfigPath := GetLocalKubeConfig(configPath, configDir)
 	if len(cpHosts) > 0 {
+		cpHostAddress := cpHosts[0].Address
+		if len(rkeConfig.ControlPlaneLoadBalancer) > 0 {
+			cpHostAddress = rkeConfig.ControlPlaneLoadBalancer
+		}
 		kubeAdminCertObj := certBundle[KubeAdminCertName]
 		kubeAdminConfig := GetKubeConfigX509WithData(
-			"https://"+cpHosts[0].Address+":6443",
+			"https://"+cpHostAddress+":6443",
 			rkeConfig.ClusterName,
 			KubeAdminCertName,
 			string(cert.EncodeCertPEM(certBundle[CACertName].Certificate)),

--- a/pki/util.go
+++ b/pki/util.go
@@ -136,10 +136,11 @@ func GenerateCACertAndKey(commonName string, privateKey *rsa.PrivateKey) (*x509.
 	return kubeCACert, rootKey, nil
 }
 
-func GetAltNames(cpHosts []*hosts.Host, clusterDomain string, KubernetesServiceIP net.IP, SANs []string) *cert.AltNames {
+// GetAltNames creates a set of X509 SANs for the hosts, services, and alternates given
+func GetAltNames(rkeHosts []*hosts.Host, clusterDomain string, KubernetesServiceIP net.IP, SANs []string) *cert.AltNames {
 	ips := []net.IP{}
 	dnsNames := []string{}
-	for _, host := range cpHosts {
+	for _, host := range rkeHosts {
 		// Check if node address is a valid IP
 		if nodeIP := net.ParseIP(host.Address); nodeIP != nil {
 			ips = append(ips, nodeIP)


### PR DESCRIPTION
Allow the configuration of a TCP load-balancer to the control-plane (kube-apiserver) hosts.

depends on:
rancher/types#987

to-do:
- [ ] remove go.mod override of rancher/types