### PR TITLE
Add per node kubelet server certificate

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -222,6 +222,10 @@ func (c *Cluster) BuildKubeAPIProcess(host *hosts.Host, prefixPath string, svcOp
 		CommandArgs["experimental-encryption-provider-config"] = EncryptionProviderFilePath
 	}
 
+	if c.IsKubeletGenerateServingCertificateEnabled() {
+		CommandArgs["kubelet-certificate-authority"] = pki.GetCertPath(pki.CACertName)
+	}
+
 	serviceOptions := c.GetKubernetesServicesOptions(host.DockerInfo.OSType, svcOptionData)
 	if serviceOptions.KubeAPI != nil {
 		for k, v := range serviceOptions.KubeAPI {
@@ -451,6 +455,11 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, prefixPath string, svcOp
 			CommandArgs["cloud-config"] = path.Join(prefixPath, cloudConfigFileName)
 		}
 	}
+	if c.IsKubeletGenerateServingCertificateEnabled() {
+		CommandArgs["tls-cert-file"] = pki.GetCertPath(pki.GetCrtNameForHost(host, pki.KubeletCertName))
+		CommandArgs["tls-private-key-file"] = pki.GetCertPath(fmt.Sprintf("%s-key", pki.GetCrtNameForHost(host, pki.KubeletCertName)))
+	}
+
 	if len(c.CloudProvider.Name) > 0 {
 		c.Services.Kubelet.ExtraEnv = append(
 			c.Services.Kubelet.ExtraEnv,
@@ -891,7 +900,7 @@ func (c *Cluster) BuildSidecarProcess(host *hosts.Host, prefixPath string) v3.Pr
 }
 
 func (c *Cluster) BuildEtcdProcess(host *hosts.Host, etcdHosts []*hosts.Host, prefixPath string) v3.Process {
-	nodeName := pki.GetEtcdCrtName(host.InternalAddress)
+	nodeName := pki.GetCrtNameForHost(host, pki.EtcdCertName)
 	initCluster := ""
 	architecture := "amd64"
 	if len(etcdHosts) == 0 {

--- a/cluster/reconcile.go
+++ b/cluster/reconcile.go
@@ -351,7 +351,7 @@ func restartComponentsWhenCertChanges(ctx context.Context, currentCluster, kubeC
 	}
 
 	for _, host := range kubeCluster.EtcdHosts {
-		etcdCertName := pki.GetEtcdCrtName(host.Address)
+		etcdCertName := pki.GetCrtNameForHost(host, pki.EtcdCertName)
 		certMap := map[string]bool{
 			etcdCertName: false,
 		}

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/rancher/kontainer-driver-metadata v0.0.0-20191021164950-6514452b9732
 	github.com/rancher/norman v0.0.0-20191003174345-0ac7dd6ccb36
-	github.com/rancher/types v0.0.0-20191029204550-4a33ba02
+	github.com/rancher/types v0.0.0-20191030200339-4ba6690e1914
 	github.com/sirupsen/logrus v1.4.2
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
@@ -63,5 +63,6 @@ require (
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v11.0.1-0.20190805182715-88a2adca7e76+incompatible
 	k8s.io/kubernetes v1.16.0
+	knative.dev/pkg v0.0.0-20191031171713-d4ce00139499 // indirect
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,10 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/OneOfOne/xxhash v1.2.5/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkFW6gg=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
@@ -110,6 +112,7 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/coreos/prometheus-operator v0.33.0 h1:mDblqA4KG+KBxOYt4mJE2coJhiHv+ScgnOvuchmgTYM=
 github.com/coreos/prometheus-operator v0.33.0/go.mod h1:Bk/PShB4YYCX7sIRLuFv2/d8WA8P2gpj8RahsGGPfy0=
 github.com/coreos/rkt v1.30.0/go.mod h1:O634mlH6U7qk87poQifK6M2rsFNt+FyUTWNMnP1hF1U=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
@@ -144,6 +147,7 @@ github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.6.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v4.1.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -185,10 +189,12 @@ github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
+github.com/go-openapi/jsonpointer v0.19.2 h1:A9+F4Dc/MCNB5jibxf6rRvOvR/iFgQdyNx9eIhnGqq0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
+github.com/go-openapi/jsonreference v0.19.2 h1:o20suLFB4Ri0tuzpWtyHlh7E7HnkqTNLq6aR6WVNS1w=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
 github.com/go-openapi/loads v0.17.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.18.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
@@ -200,6 +206,7 @@ github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nA
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.17.2/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
+github.com/go-openapi/spec v0.19.2 h1:SStNd1jRcYtfKCN7R0laGNs80WYYvn5CbBjM2sOmCrE=
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
@@ -207,6 +214,7 @@ github.com/go-openapi/strfmt v0.19.0/go.mod h1:+uW+93UVvGGq2qGaZxdDeJqSAqBqBdl+Z
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
+github.com/go-openapi/swag v0.19.2 h1:jvO6bCMBEilGwMfHhrd61zIID4oIFdwb76V17SM88dE=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
@@ -332,6 +340,7 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/knative/pkg v0.0.0-20190817231834-12ee58e32cc8 h1:cYUW0Hf44iFo34VdB9UYXlqLTnUvw2jwocJZkvLlhg0=
 github.com/knative/pkg v0.0.0-20190817231834-12ee58e32cc8/go.mod h1:7Ijfhw7rfB+H9VtosIsDYvZQ+qYTz7auK3fHW/5z4ww=
 github.com/knz/strtime v0.0.0-20181018220328-af2256ee352c/go.mod h1:4ZxfWkxwtc7dBeifERVVWRy9F9rTU9p0yCDgeCtlius=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
@@ -359,10 +368,12 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63 h1:nTT4s92Dgz2HlrB2NaMgvlfqHH39OgMhA7z3PK7PGD4=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/maruel/panicparse v0.0.0-20171209025017-c0182c169410/go.mod h1:nty42YY5QByNC5MM7q/nj938VbgPU7avs45z6NClpxI=
 github.com/maruel/ut v1.0.0/go.mod h1:I68ffiAt5qre9obEVTy7S2/fj2dJku2NYLvzPuY0gqE=
+github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd h1:HvFwW+cm9bCbZ/+vuGNq7CRWXql8c0y8nGeYpqmpvmk=
 github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.0 h1:v2XXALHHh6zHfYTJ+cSkwtyffnaOyR1MXaA91mTrb8o=
@@ -488,6 +499,8 @@ github.com/rancher/types v0.0.0-20191029204550-4a33ba02 h1:j1HUtCuV7SyAH4QB9vK8u
 github.com/rancher/types v0.0.0-20191029204550-4a33ba02/go.mod h1:K5zlxVpe7bY2QgOs1YUcU8dVXtzKncxpGEcvxGMgr0k=
 github.com/rancher/types v0.0.0-20191029204550-fb419769977e h1:MyLcPP5v6o8ZHQHcUCV/N5dhFpDzVIpYmIe7+lu7CZQ=
 github.com/rancher/types v0.0.0-20191029204550-fb419769977e/go.mod h1:vU8TDxlonzOAzN97t0BX5CbtLG4NKOaimsVhByrnYzk=
+github.com/rancher/types v0.0.0-20191030200339-4ba6690e1914 h1:tAK9EisbgTKw+F4i5WWG1s6eeJYtSiTqSUFkPJDWsSY=
+github.com/rancher/types v0.0.0-20191030200339-4ba6690e1914/go.mod h1:K5zlxVpe7bY2QgOs1YUcU8dVXtzKncxpGEcvxGMgr0k=
 github.com/rancher/wrangler v0.1.5 h1:HiXOeP6Kci2DK+e04D1g6INT77xAYpAr54zmTTe0Spk=
 github.com/rancher/wrangler v0.1.5/go.mod h1:EYP7cqpg42YqElaCm+U9ieSrGQKAXxUH5xsr+XGpWyE=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -681,6 +694,7 @@ golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190926165942-a8d5d34286bd/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c h1:IGkKhmfzcztjm6gYkykvu/NiS8kaqbCWAEWWAyf8J5U=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
@@ -760,6 +774,7 @@ k8s.io/cri-api v0.0.0-20190828162817-608eb1dad4ac/go.mod h1:BvtUaNBr0fEpzb11OfrQ
 k8s.io/csi-translation-lib v0.0.0-20190918163402-db86a8c7bb21/go.mod h1:Ja9f0K9MkTuUSyBgpjFt2am69TOjrmkQUN25WTF3CCM=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20190822140433-26a664648505 h1:ZY6yclUKVbZ+SdWnkfY+Je5vrMpKOxmGeKRbsXVmqYM=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -768,11 +783,13 @@ k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.4.0 h1:lCJCxf/LIowc2IGS9TPjWDyXY4nOmdGdfcwwDQCOURQ=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/kube-aggregator v0.0.0-20190918161219-8c8f079fddc3 h1:Qscw8cxevIcxULoLXwNgcIPbGCGCaGHlh5HpTE8N8C8=
 k8s.io/kube-aggregator v0.0.0-20190918161219-8c8f079fddc3/go.mod h1:NJisPUqwlg1A99RhO1BTnNtwC4pKUyXJ2f3Xc4PxKQg=
 k8s.io/kube-controller-manager v0.0.0-20190918162944-7a93a0ddadd8/go.mod h1:+HrHoqJm0UqnlrBEKXGzs2701YN4+ozi76oG7iYvJ8s=
 k8s.io/kube-openapi v0.0.0-20180629012420-d83b052f768a/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20190502190224-411b2483e503/go.mod h1:iU+ZGYsNlvU9XKUSso6SQfKTCCw7lFduMZy26Mgr2Fw=
+k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf h1:EYm5AW/UUDbnmnI+gK0TJDVK9qPLhM+sRHYanNKw0EQ=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-proxy v0.0.0-20190918162534-de037b596c1e/go.mod h1:/48p8Y6dkWJrll4tsceAoGKudGpRmtQu/u1zlG14NnI=
 k8s.io/kube-scheduler v0.0.0-20190918162820-3b5c1246eb18/go.mod h1:k2dnGirIGylr51dpqxn2Zv6Yt47A+6NiynBIYfAU67I=
@@ -787,6 +804,8 @@ k8s.io/sample-apiserver v0.0.0-20190918161442-d4c9c65c82af/go.mod h1:HP/BmiRyZTM
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1 h1:+ySTxfHnfzZb9ys375PXNlLhkJPLKgHajBU0N62BDvE=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+knative.dev/pkg v0.0.0-20191031171713-d4ce00139499 h1:IKyFaHs+5R3riP/MZ4W2718UUJOYEoDcRFlzJGMeftY=
+knative.dev/pkg v0.0.0-20191031171713-d4ce00139499/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/hosts/hosts.go
+++ b/hosts/hosts.go
@@ -274,6 +274,16 @@ func buildCleanerConfig(host *Host, toCleanDirs []string, cleanerImage string) (
 
 func NodesToHosts(rkeNodes []v3.RKEConfigNode, nodeRole string) []*Host {
 	hostList := make([]*Host, 0)
+	// Return all nodes if there is no noderole passed to the function
+	if nodeRole == "" {
+		for _, node := range rkeNodes {
+			newHost := Host{
+				RKEConfigNode: node,
+			}
+			hostList = append(hostList, &newHost)
+		}
+		return hostList
+	}
 	for _, node := range rkeNodes {
 		for _, role := range node.Role {
 			if role == nodeRole {

--- a/pki/constants.go
+++ b/pki/constants.go
@@ -21,6 +21,7 @@ const (
 	KubeSchedulerCertName      = "kube-scheduler"
 	KubeProxyCertName          = "kube-proxy"
 	KubeNodeCertName           = "kube-node"
+	KubeletCertName            = "kube-kubelet"
 	EtcdCertName               = "kube-etcd"
 	EtcdClientCACertName       = "kube-etcd-client-ca"
 	EtcdClientCertName         = "kube-etcd-client"

--- a/pki/deploy.go
+++ b/pki/deploy.go
@@ -26,6 +26,16 @@ const (
 func DeployCertificatesOnPlaneHost(ctx context.Context, host *hosts.Host, rkeConfig v3.RancherKubernetesEngineConfig, crtMap map[string]CertificatePKI, certDownloaderImage string, prsMap map[string]v3.PrivateRegistry, forceDeploy bool) error {
 	crtBundle := GenerateRKENodeCerts(ctx, rkeConfig, host.Address, crtMap)
 	env := []string{}
+
+	// Strip CA key as its sensitive and unneeded on nodes without controlplane role
+	if !host.IsControl {
+		caCert := crtBundle[CACertName]
+		caCert.Key = nil
+		caCert.KeyEnvName = ""
+		caCert.KeyPath = ""
+		crtBundle[CACertName] = caCert
+	}
+
 	for _, crt := range crtBundle {
 		env = append(env, crt.ToEnv()...)
 	}
@@ -192,7 +202,7 @@ func FetchCertificatesFromHost(ctx context.Context, extraHosts []*hosts.Host, ho
 
 	for _, etcdHost := range extraHosts {
 		// Fetch etcd certificates
-		crtList[GetEtcdCrtName(etcdHost.InternalAddress)] = false
+		crtList[GetCrtNameForHost(etcdHost, EtcdCertName)] = false
 	}
 
 	for certName, config := range crtList {

--- a/pki/services.go
+++ b/pki/services.go
@@ -30,7 +30,7 @@ func GenerateKubeAPICertificate(ctx context.Context, certs map[string]Certificat
 	kubeAPICert := certs[KubeAPICertName].Certificate
 	if kubeAPICert != nil &&
 		reflect.DeepEqual(kubeAPIAltNames.DNSNames, kubeAPICert.DNSNames) &&
-		deepEqualIPsAltNames(kubeAPIAltNames.IPs, kubeAPICert.IPAddresses) && !rotate {
+		DeepEqualIPsAltNames(kubeAPIAltNames.IPs, kubeAPICert.IPAddresses) && !rotate {
 		return nil
 	}
 	log.Infof(ctx, "[certificates] Generating Kubernetes API server certificates")
@@ -65,7 +65,7 @@ func GenerateKubeAPICSR(ctx context.Context, certs map[string]CertificatePKI, rk
 	oldKubeAPICSR := certs[KubeAPICertName].CSR
 	if oldKubeAPICSR != nil &&
 		reflect.DeepEqual(kubeAPIAltNames.DNSNames, oldKubeAPICSR.DNSNames) &&
-		deepEqualIPsAltNames(kubeAPIAltNames.IPs, oldKubeAPICSR.IPAddresses) {
+		DeepEqualIPsAltNames(kubeAPIAltNames.IPs, oldKubeAPICSR.IPAddresses) {
 		return nil
 	}
 	log.Infof(ctx, "[certificates] Generating Kubernetes API server csr")
@@ -372,7 +372,7 @@ func GenerateEtcdCertificates(ctx context.Context, certs map[string]CertificateP
 	sort.Strings(ips)
 
 	for _, host := range etcdHosts {
-		etcdName := GetEtcdCrtName(host.InternalAddress)
+		etcdName := GetCrtNameForHost(host, EtcdCertName)
 		if _, ok := certs[etcdName]; ok && certs[etcdName].CertificatePEM != "" && !rotate {
 			cert := certs[etcdName].Certificate
 			if cert != nil && len(dnsNames) == len(cert.DNSNames) && len(ips) == len(cert.IPAddresses) {
@@ -396,7 +396,7 @@ func GenerateEtcdCertificates(ctx context.Context, certs map[string]CertificateP
 		if !rotate {
 			serviceKey = certs[etcdName].Key
 		}
-		log.Infof(ctx, "[certificates] Generating etcd-%s certificate and key", host.InternalAddress)
+		log.Infof(ctx, "[certificates] Generating %s certificate and key", etcdName)
 		etcdCrt, etcdKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, EtcdCertName, etcdAltNames, serviceKey, nil)
 		if err != nil {
 			return err
@@ -415,7 +415,7 @@ func GenerateEtcdCSRs(ctx context.Context, certs map[string]CertificatePKI, rkeC
 	etcdHosts := hosts.NodesToHosts(rkeConfig.Nodes, etcdRole)
 	etcdAltNames := GetAltNames(etcdHosts, clusterDomain, kubernetesServiceIP, []string{})
 	for _, host := range etcdHosts {
-		etcdName := GetEtcdCrtName(host.InternalAddress)
+		etcdName := GetCrtNameForHost(host, EtcdCertName)
 		etcdCrt := certs[etcdName].Certificate
 		etcdCSRPEM := certs[etcdName].CSRPEM
 		if etcdCSRPEM != "" {
@@ -484,6 +484,63 @@ func GenerateRKERequestHeaderCACert(ctx context.Context, certs map[string]Certif
 	return nil
 }
 
+func GenerateKubeletCertificate(ctx context.Context, certs map[string]CertificatePKI, rkeConfig v3.RancherKubernetesEngineConfig, configPath, configDir string, rotate bool) error {
+	// generate kubelet certificate and key
+	caCrt := certs[CACertName].Certificate
+	caKey := certs[CACertName].Key
+	if caCrt == nil || caKey == nil {
+		return fmt.Errorf("CA Certificate or Key is empty")
+	}
+	log.Infof(ctx, "[certificates] Generating Kubernetes Kubelet certificates")
+	allHosts := hosts.NodesToHosts(rkeConfig.Nodes, "")
+	for _, host := range allHosts {
+		kubeletName := GetCrtNameForHost(host, KubeletCertName)
+		kubeletCert := certs[kubeletName].Certificate
+		if kubeletCert != nil && !rotate {
+			continue
+		}
+		kubeletAltNames := GetIPHostAltnamesForHost(host)
+		if kubeletCert != nil &&
+			reflect.DeepEqual(kubeletAltNames.DNSNames, kubeletCert.DNSNames) &&
+			DeepEqualIPsAltNames(kubeletAltNames.IPs, kubeletCert.IPAddresses) && !rotate {
+			continue
+		}
+		var serviceKey *rsa.PrivateKey
+		if !rotate {
+			serviceKey = certs[kubeletName].Key
+		}
+		log.Infof(ctx, "[certificates] Generating %s certificate and key", kubeletName)
+		kubeletCrt, kubeletKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, kubeletName, kubeletAltNames, serviceKey, nil)
+		if err != nil {
+			return err
+		}
+		certs[kubeletName] = ToCertObject(kubeletName, "", "", kubeletCrt, kubeletKey, nil)
+	}
+	return nil
+}
+
+func GenerateKubeletCSR(ctx context.Context, certs map[string]CertificatePKI, rkeConfig v3.RancherKubernetesEngineConfig) error {
+	allHosts := hosts.NodesToHosts(rkeConfig.Nodes, "")
+	for _, host := range allHosts {
+		kubeletName := GetCrtNameForHost(host, KubeletCertName)
+		kubeletCert := certs[kubeletName].Certificate
+		oldKubeletCSR := certs[kubeletName].CSR
+		kubeletAltNames := GetIPHostAltnamesForHost(host)
+		if oldKubeletCSR != nil &&
+			reflect.DeepEqual(kubeletAltNames.DNSNames, oldKubeletCSR.DNSNames) &&
+			DeepEqualIPsAltNames(kubeletAltNames.IPs, oldKubeletCSR.IPAddresses) {
+			return nil
+		}
+		log.Infof(ctx, "[certificates] Generating %s Kubernetes Kubelet csr", kubeletName)
+		kubeletCSR, kubeletKey, err := GenerateCertSigningRequestAndKey(true, kubeletName, kubeletAltNames, certs[kubeletName].Key, nil)
+		if err != nil {
+			return err
+		}
+		certs[kubeletName] = ToCertObject(kubeletName, "", "", kubeletCert, kubeletKey, kubeletCSR)
+	}
+	return nil
+}
+
 func GenerateRKEServicesCerts(ctx context.Context, certs map[string]CertificatePKI, rkeConfig v3.RancherKubernetesEngineConfig, configPath, configDir string, rotate bool) error {
 	RKECerts := []GenFunc{
 		GenerateKubeAPICertificate,
@@ -495,6 +552,9 @@ func GenerateRKEServicesCerts(ctx context.Context, certs map[string]CertificateP
 		GenerateKubeAdminCertificate,
 		GenerateAPIProxyClientCertificate,
 		GenerateEtcdCertificates,
+	}
+	if IsKubeletGenerateServingCertificateEnabledinConfig(&rkeConfig) {
+		RKECerts = append(RKECerts, GenerateKubeletCertificate)
 	}
 	for _, gen := range RKECerts {
 		if err := gen(ctx, certs, rkeConfig, configPath, configDir, rotate); err != nil {
@@ -517,6 +577,9 @@ func GenerateRKEServicesCSRs(ctx context.Context, certs map[string]CertificatePK
 		GenerateKubeAdminCSR,
 		GenerateAPIProxyClientCSR,
 		GenerateEtcdCSRs,
+	}
+	if IsKubeletGenerateServingCertificateEnabledinConfig(&rkeConfig) {
+		RKECerts = append(RKECerts, GenerateKubeletCSR)
 	}
 	for _, csr := range RKECerts {
 		if err := csr(ctx, certs, rkeConfig); err != nil {

--- a/pki/util.go
+++ b/pki/util.go
@@ -135,6 +135,34 @@ func GenerateCACertAndKey(commonName string, privateKey *rsa.PrivateKey) (*x509.
 	return kubeCACert, rootKey, nil
 }
 
+func GetIPHostAltnamesForHost(host *hosts.Host) *cert.AltNames {
+	var ips []net.IP
+	dnsNames := []string{}
+	// Check if node address is a valid IP
+	if nodeIP := net.ParseIP(host.Address); nodeIP != nil {
+		ips = append(ips, nodeIP)
+	} else {
+		dnsNames = append(dnsNames, host.Address)
+	}
+
+	// Check if node internal address is a valid IP
+	if len(host.InternalAddress) != 0 && host.InternalAddress != host.Address {
+		if internalIP := net.ParseIP(host.InternalAddress); internalIP != nil {
+			ips = append(ips, internalIP)
+		} else {
+			dnsNames = append(dnsNames, host.InternalAddress)
+		}
+	}
+	// Add hostname to the ALT dns names
+	if len(host.HostnameOverride) != 0 && host.HostnameOverride != host.Address {
+		dnsNames = append(dnsNames, host.HostnameOverride)
+	}
+	return &cert.AltNames{
+		IPs:      ips,
+		DNSNames: dnsNames,
+	}
+}
+
 func GetAltNames(cpHosts []*hosts.Host, clusterDomain string, KubernetesServiceIP net.IP, SANs []string) *cert.AltNames {
 	ips := []net.IP{}
 	dnsNames := []string{}
@@ -224,9 +252,14 @@ func getConfigEnvFromEnv(env string) string {
 	return fmt.Sprintf("KUBECFG_%s", env)
 }
 
-func GetEtcdCrtName(address string) string {
-	newAddress := strings.Replace(address, ".", "-", -1)
-	return fmt.Sprintf("%s-%s", EtcdCertName, newAddress)
+func GetCrtNameForHost(host *hosts.Host, prefix string) string {
+	var newAddress string
+	if len(host.InternalAddress) != 0 && host.InternalAddress != host.Address {
+		newAddress = strings.Replace(host.InternalAddress, ".", "-", -1)
+	} else {
+		newAddress = strings.Replace(host.Address, ".", "-", -1)
+	}
+	return fmt.Sprintf("%s-%s", prefix, newAddress)
 }
 
 func GetCertPath(name string) string {
@@ -279,7 +312,7 @@ func ToCertObject(componentName, commonName, ouName string, certificate *x509.Ce
 		})
 	}
 
-	if componentName != CACertName && componentName != KubeAPICertName && !strings.Contains(componentName, EtcdCertName) && componentName != ServiceAccountTokenKeyName {
+	if componentName != CACertName && componentName != KubeAPICertName && !strings.Contains(componentName, EtcdCertName) && !strings.Contains(componentName, KubeletCertName) && componentName != ServiceAccountTokenKeyName {
 		config = getKubeConfigX509("https://127.0.0.1:6443", "local", componentName, caCertPath, path, keyPath)
 		configPath = GetConfigPath(componentName)
 		configEnvName = getConfigEnvFromEnv(envName)
@@ -309,42 +342,41 @@ func getDefaultCN(name string) string {
 	return fmt.Sprintf("system:%s", name)
 }
 
-func getControlCertKeys() []string {
-	return []string{
-		CACertName,
-		KubeAPICertName,
-		ServiceAccountTokenKeyName,
-		KubeControllerCertName,
-		KubeSchedulerCertName,
-		KubeProxyCertName,
-		KubeNodeCertName,
-		EtcdClientCertName,
-		EtcdClientCACertName,
-		RequestHeaderCACertName,
-		APIProxyClientCertName,
+func getCertKeys(rkeNodes []v3.RKEConfigNode, nodeRole string, rkeConfig *v3.RancherKubernetesEngineConfig) []string {
+	// static certificates each node needs
+	certList := []string{CACertName, KubeProxyCertName, KubeNodeCertName}
+	allHosts := hosts.NodesToHosts(rkeNodes, "")
+	if IsKubeletGenerateServingCertificateEnabledinConfig(rkeConfig) {
+		for _, host := range allHosts {
+			// Add per node kubelet certificates (used for kube-api -> kubelet connection)
+			certList = append(certList, GetCrtNameForHost(host, KubeletCertName))
+		}
 	}
-}
-
-func getWorkerCertKeys() []string {
-	return []string{
-		CACertName,
-		KubeProxyCertName,
-		KubeNodeCertName,
+	// etcd
+	if nodeRole == etcdRole {
+		etcdHosts := hosts.NodesToHosts(rkeNodes, nodeRole)
+		for _, host := range etcdHosts {
+			certList = append(certList, GetCrtNameForHost(host, EtcdCertName))
+		}
+		return certList
 	}
-}
-
-func getEtcdCertKeys(rkeNodes []v3.RKEConfigNode, etcdRole string) []string {
-	certList := []string{
-		CACertName,
-		KubeProxyCertName,
-		KubeNodeCertName,
+	// control
+	if nodeRole == controlRole {
+		controlCertList := []string{
+			KubeAPICertName,
+			ServiceAccountTokenKeyName,
+			KubeControllerCertName,
+			KubeSchedulerCertName,
+			EtcdClientCertName,
+			EtcdClientCACertName,
+			RequestHeaderCACertName,
+			APIProxyClientCertName,
+		}
+		certList = append(certList, controlCertList...)
+		return certList
 	}
-	etcdHosts := hosts.NodesToHosts(rkeNodes, etcdRole)
-	for _, host := range etcdHosts {
-		certList = append(certList, GetEtcdCrtName(host.InternalAddress))
-	}
+	// worker
 	return certList
-
 }
 
 func GetKubernetesServiceIP(serviceClusterRange string) (net.IP, error) {
@@ -393,7 +425,7 @@ func populateCertMap(tmpCerts map[string]CertificatePKI, localConfigPath string,
 	certs[KubeAdminCertName] = kubeAdminCertObj
 	// etcd
 	for _, host := range extraHosts {
-		etcdName := GetEtcdCrtName(host.InternalAddress)
+		etcdName := GetCrtNameForHost(host, EtcdCertName)
 		etcdCrt, etcdKey := tmpCerts[etcdName].Certificate, tmpCerts[etcdName].Key
 		certs[etcdName] = ToCertObject(etcdName, "", "", etcdCrt, etcdKey, nil)
 	}
@@ -466,7 +498,7 @@ func isFileNotFoundErr(e error) bool {
 	return false
 }
 
-func deepEqualIPsAltNames(oldIPs, newIPs []net.IP) bool {
+func DeepEqualIPsAltNames(oldIPs, newIPs []net.IP) bool {
 	if len(oldIPs) != len(newIPs) {
 		return false
 	}
@@ -696,7 +728,7 @@ func ValidateBundleContent(rkeConfig *v3.RancherKubernetesEngineConfig, certBund
 	}
 	etcdHosts := hosts.NodesToHosts(rkeConfig.Nodes, etcdRole)
 	for _, host := range etcdHosts {
-		etcdName := GetEtcdCrtName(host.InternalAddress)
+		etcdName := GetCrtNameForHost(host, EtcdCertName)
 		if certBundle[etcdName].Certificate == nil || certBundle[etcdName].Key == nil {
 			return fmt.Errorf("Failed to find etcd [%s] Certificate or Key", etcdName)
 		}
@@ -733,7 +765,7 @@ func validateCAIssuer(rkeConfig *v3.RancherKubernetesEngineConfig, certBundle ma
 	}
 	etcdHosts := hosts.NodesToHosts(rkeConfig.Nodes, etcdRole)
 	for _, host := range etcdHosts {
-		etcdName := GetEtcdCrtName(host.InternalAddress)
+		etcdName := GetCrtNameForHost(host, EtcdCertName)
 		ComponentsCerts = append(ComponentsCerts, etcdName)
 	}
 	for _, componentCert := range ComponentsCerts {
@@ -762,4 +794,11 @@ func IsValidCertStr(c string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func IsKubeletGenerateServingCertificateEnabledinConfig(rkeConfig *v3.RancherKubernetesEngineConfig) bool {
+	if rkeConfig.Services.Kubelet.GenerateServingCertificate {
+		return true
+	}
+	return false
 }

--- a/services/etcd.go
+++ b/services/etcd.go
@@ -428,7 +428,7 @@ func DownloadEtcdSnapshotFromS3(ctx context.Context, etcdHost *hosts.Host, prsMa
 
 func RestoreEtcdSnapshot(ctx context.Context, etcdHost *hosts.Host, prsMap map[string]v3.PrivateRegistry, etcdRestoreImage, snapshotName, initCluster string, es v3.ETCDService) error {
 	log.Infof(ctx, "[etcd] Restoring [%s] snapshot on etcd host [%s]", snapshotName, etcdHost.Address)
-	nodeName := pki.GetEtcdCrtName(etcdHost.InternalAddress)
+	nodeName := pki.GetCrtNameForHost(etcdHost, pki.EtcdCertName)
 	snapshotPath := fmt.Sprintf("%s%s", EtcdSnapshotPath, snapshotName)
 
 	// make sure that restore path is empty otherwise etcd restore will fail

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/rke_types.go
@@ -324,6 +324,8 @@ type KubeletService struct {
 	ClusterDNSServer string `yaml:"cluster_dns_server" json:"clusterDnsServer,omitempty"`
 	// Fail if swap is enabled
 	FailSwapOn bool `yaml:"fail_swap_on" json:"failSwapOn,omitempty"`
+	// Generate per node kubelet serving certificates created using kube-ca
+	GenerateServingCertificate bool `yaml:"generate_serving_certificate" json:"generateServingCertificate,omitempty"`
 }
 
 type KubeproxyService struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -131,7 +131,7 @@ github.com/rancher/norman/types/definition
 github.com/rancher/norman/types/slice
 github.com/rancher/norman/types/values
 github.com/rancher/norman/metrics
-# github.com/rancher/types v0.0.0-20191029204550-4a33ba02
+# github.com/rancher/types v0.0.0-20191030200339-4ba6690e1914
 github.com/rancher/types/apis/management.cattle.io/v3
 github.com/rancher/types/apis/project.cattle.io/v3
 github.com/rancher/types/image


### PR DESCRIPTION
* Moved stripping CA key from `GenerateRKENodeCerts` to `DeployCertificatesOnPlaneHost` because we use `GenerateRKENodeCerts` in Rancher worker logic to generate the kubelet certificate and I can't do that without the CA key.
* Implemented `GetCrtNameForHost` to get certificate name as Rancher does not default nodes to have `InternalAddress` equal to `Address` when `InternalAddress` is empty (which RKE does).
* Made `DeepEqualIPsAltNames` public as it is needed in the nodeconfig comparing old vs new cert

Depends on https://github.com/rancher/types/pull/1013