### PR TITLE
Provide IP for kube-proxy if cloudprovider is set

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -585,6 +585,14 @@ func (c *Cluster) BuildKubeProxyProcess(host *hosts.Host, prefixPath string, svc
 			CommandArgs[k] = v
 		}
 	}
+	// If cloudprovider is set (not empty), set the bind address because the node will not be able to retrieve it's IP address in case cloud provider changes the node object name (i.e. AWS and Openstack)
+	if c.CloudProvider.Name != "" {
+		if host.InternalAddress != "" && host.Address != host.InternalAddress {
+			CommandArgs["bind-address"] = host.InternalAddress
+		} else {
+			CommandArgs["bind-address"] = host.Address
+		}
+	}
 
 	// Best security practice is to listen on localhost, but DinD uses private container network instead of Host.
 	if c.DinD {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/22814

If cloudprovider is set (not empty), set the bind address because the node will not be able to retrieve it's IP address because the nodename could be set by the cloud provider (e.g. AWS and Openstack)

After running into other issues that had similar logic, we changed from checking for AWS only to if any cloud provider is set. We also added the check for `InternalAddress` being empty.