### PR TITLE
Revert bind mounting ipvs lib for windows since it causes failure with Windows agent

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -654,7 +654,6 @@ func (c *Cluster) BuildKubeProxyProcess(host *hosts.Host, prefixPath string, svc
 			fmt.Sprintf("%s:c:/host/etc/kubernetes", path.Join(prefixPath, "/etc/kubernetes")),
 			// exchange resources with other components
 			fmt.Sprintf("%s:c:/host/run", path.Join(prefixPath, "/run")),
-			fmt.Sprintf("%s:c:/host/lib/modules", path.Join(prefixPath, "/lib/modules")),
 		}
 	}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/23847

Reverting the change done in this PR for Windows only - https://github.com/rancher/rke/pull/1724
@thxCode @loganhz