### PR TITLE
Add time checking on cluster provisioning

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -86,6 +86,7 @@ type ExternalFlags struct {
 	ConfigDir        string
 	CustomCerts      bool
 	DisablePortCheck bool
+	DisableTimeCheck bool
 	GenerateCSR      bool
 	Local            bool
 	UpdateOnly       bool
@@ -530,11 +531,12 @@ func (c *Cluster) setCloudProvider() error {
 	return nil
 }
 
-func GetExternalFlags(local, updateOnly, disablePortCheck bool, configDir, clusterFilePath string) ExternalFlags {
+func GetExternalFlags(local, updateOnly, disablePortCheck bool, disableTimeCheck bool, configDir, clusterFilePath string) ExternalFlags {
 	return ExternalFlags{
 		Local:            local,
 		UpdateOnly:       updateOnly,
 		DisablePortCheck: disablePortCheck,
+		DisableTimeCheck: disableTimeCheck,
 		ConfigDir:        configDir,
 		ClusterFilePath:  clusterFilePath,
 	}

--- a/cluster/state.go
+++ b/cluster/state.go
@@ -53,7 +53,7 @@ func (c *Cluster) GetClusterState(ctx context.Context, fullState *FullState) (*C
 	}
 
 	// resetup external flags
-	flags := GetExternalFlags(false, false, false, c.ConfigDir, c.ConfigPath)
+	flags := GetExternalFlags(false, false, false, false, c.ConfigDir, c.ConfigPath)
 	currentCluster, err := InitClusterObject(ctx, fullState.CurrentState.RancherKubernetesEngineConfig, flags, fullState.CurrentState.EncryptionConfig)
 	if err != nil {
 		return nil, err

--- a/cluster/timecheck.go
+++ b/cluster/timecheck.go
@@ -1,0 +1,94 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/rancher/rke/docker"
+	"github.com/rancher/rke/hosts"
+	"github.com/rancher/rke/log"
+	"github.com/rancher/rke/util"
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	TimeCheckContainer = "rke-time-checker"
+)
+
+func (c *Cluster) CheckClusterTime(ctx context.Context, currentCluster *Cluster) error {
+	allHosts := hosts.GetUniqueHostList(c.EtcdHosts, c.ControlPlaneHosts, c.WorkerHosts)
+	var errgrp errgroup.Group
+	hostsQueue := util.GetObjectQueue(allHosts)
+	for w := 0; w < WorkerThreads; w++ {
+		errgrp.Go(func() error {
+			var errList []error
+			for host := range hostsQueue {
+				err := c.checkTimeDiffLocalVsNode(ctx, host.(*hosts.Host), c.SystemImages.Alpine, c.PrivateRegistriesMap)
+				if err != nil {
+					errList = append(errList, err)
+				}
+			}
+			return util.ErrList(errList)
+		})
+	}
+	if err := errgrp.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Cluster) checkTimeDiffLocalVsNode(ctx context.Context, host *hosts.Host, image string, prsMap map[string]v3.PrivateRegistry) error {
+	imageCfg := &container.Config{
+		Image: image,
+		Cmd: []string{
+			"date",
+			"+%s",
+		},
+	}
+	hostCfg := &container.HostConfig{
+		LogConfig: container.LogConfig{
+			Type: "json-file",
+		},
+	}
+	if err := docker.DoRemoveContainer(ctx, host.DClient, TimeCheckContainer, host.Address); err != nil {
+		return err
+	}
+	// Closest point to actual running the container
+	startEpoch := util.GetEpochTime()
+	logrus.Debugf("[time] Time on local host: [%d] [%s]", startEpoch, time.Unix(startEpoch, 0).UTC())
+	if err := docker.DoRunOnetimeContainer(ctx, host.DClient, imageCfg, hostCfg, TimeCheckContainer, host.Address, "time", prsMap); err != nil {
+		return err
+	}
+	endEpoch := util.GetEpochTime()
+
+	containerStderrLog, containerStdoutLog, logsErr := docker.GetContainerLogsStdoutStderr(ctx, host.DClient, TimeCheckContainer, "all", true)
+	if logsErr != nil {
+		log.Warnf(ctx, "[time] Failed to get time check logs: %v, logsErr: %v", containerStderrLog, logsErr)
+	}
+	logrus.Debugf("[time] containerStdoutLog [%s] on host: %s", strings.TrimSuffix(containerStdoutLog, "\n"), host.Address)
+
+	if err := docker.RemoveContainer(ctx, host.DClient, host.Address, TimeCheckContainer); err != nil {
+		return err
+	}
+	strippedContainerStdoutLog := strings.TrimSuffix(containerStdoutLog, "\n")
+	remoteEpoch, _ := strconv.Atoi(strippedContainerStdoutLog)
+	remoteEpochInt64 := int64(remoteEpoch)
+	logrus.Debugf("[time] Time on remote host [%s]: [%d] [%s]", host.Address, remoteEpochInt64, time.Unix(remoteEpochInt64, 0).UTC())
+	hostname, _ := os.Hostname()
+	// If local time is later than remote, certificate will not be valid yet
+	if startEpoch > remoteEpochInt64 {
+		return fmt.Errorf("[time] time [%s] on host [%s] is earlier than time [%s] on host [%s] used for provisioning. Please correct time on the host(s) or use time synchronization software", time.Unix(remoteEpochInt64, 0).UTC(), host.Address, time.Unix(startEpoch, 0).UTC(), hostname)
+	}
+	// If remote time is later than local time, it won't break directly but is still an issue
+	if remoteEpochInt64 > endEpoch {
+		logrus.Warningf("[time] Time [%s] on host [%s] is later than time [%s] on host [%s] used for provisioning", time.Unix(remoteEpochInt64, 0).UTC(), host.Address, time.Unix(endEpoch, 0).UTC(), hostname)
+	}
+	return nil
+}

--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -90,7 +90,7 @@ func rotateRKECertificatesFromCli(ctx *cli.Context) error {
 		return err
 	}
 	// setting up the flags
-	externalFlags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	externalFlags := cluster.GetExternalFlags(false, false, false, false, "", filePath)
 	// setting up rotate flags
 	rkeConfig.RotateCertificates = &v3.RotateCertificates{
 		CACertificates: rotateCACerts,
@@ -119,7 +119,7 @@ func generateCSRFromCli(ctx *cli.Context) error {
 		return err
 	}
 	// setting up the flags
-	externalFlags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	externalFlags := cluster.GetExternalFlags(false, false, false, false, "", filePath)
 	externalFlags.CertificateDir = ctx.String("cert-dir")
 	externalFlags.CustomCerts = ctx.Bool("custom-certs")
 

--- a/cmd/encryption.go
+++ b/cmd/encryption.go
@@ -55,7 +55,7 @@ func rotateEncryptionKeyFromCli(ctx *cli.Context) error {
 	}
 
 	// setting up the flags
-	flags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	flags := cluster.GetExternalFlags(false, false, false, false, "", filePath)
 
 	return RotateEncryptionKey(context.Background(), rkeConfig, hosts.DialersOptions{}, flags)
 }

--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -203,7 +203,7 @@ func SnapshotSaveEtcdHostsFromCli(ctx *cli.Context) error {
 		logrus.Warnf("Name of the snapshot is not specified using [%s]", etcdSnapshotName)
 	}
 	// setting up the flags
-	flags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	flags := cluster.GetExternalFlags(false, false, false, false, "", filePath)
 
 	return SnapshotSaveEtcdHosts(context.Background(), rkeConfig, hosts.DialersOptions{}, flags, etcdSnapshotName)
 }
@@ -229,7 +229,7 @@ func RestoreEtcdSnapshotFromCli(ctx *cli.Context) error {
 		return fmt.Errorf("you must specify the snapshot name to restore")
 	}
 	// setting up the flags
-	flags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	flags := cluster.GetExternalFlags(false, false, false, false, "", filePath)
 
 	_, _, _, _, _, err = RestoreEtcdSnapshot(context.Background(), rkeConfig, hosts.DialersOptions{}, flags, map[string]interface{}{}, etcdSnapshotName)
 	return err

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -116,7 +116,7 @@ func clusterRemoveFromCli(ctx *cli.Context) error {
 	}
 
 	// setting up the flags
-	flags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	flags := cluster.GetExternalFlags(false, false, false, false, "", filePath)
 
 	return ClusterRemove(context.Background(), rkeConfig, hosts.DialersOptions{}, flags)
 }
@@ -140,7 +140,7 @@ func clusterRemoveLocal(ctx *cli.Context) error {
 		return err
 	}
 	// setting up the flags
-	flags := cluster.GetExternalFlags(true, false, false, "", filePath)
+	flags := cluster.GetExternalFlags(true, false, false, false, "", filePath)
 
 	return ClusterRemove(context.Background(), rkeConfig, hosts.DialersOptions{}, flags)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/rancher/rke/metadata"
 
@@ -160,4 +161,8 @@ func PrintProxyEnvVars() {
 			logrus.Infof("Using proxy environment variable %s with value [%s]", key, value)
 		}
 	}
+}
+
+func GetEpochTime() int64 {
+	return time.Now().Unix()
 }


### PR DESCRIPTION
https://github.com/rancher/rke/issues/1123

For Rancher, this needs a vendor of https://github.com/rancher/kontainer-engine/pull/196

How this works:

 Time on provisioning end (host where RKE up is ran or where the Rancher container/pod) is taken, and compared to the time on the nodes in the cluster. We error out as soon as the time on the nodes is earlier than the provisioning end as the certificate will not be valid yet. If it's later on the nodes, we log a warning as it might still work and we don't want to break directly.
