### PR TITLE
Deploy cloud-config file while contents are empty

### DIFF
--- a/cluster/file-deployer.go
+++ b/cluster/file-deployer.go
@@ -36,7 +36,9 @@ func doDeployFile(ctx context.Context, host *hosts.Host, fileName, fileContents,
 	}
 	var cmd, containerEnv []string
 
-	if fileContents != "" {
+	// fileContents determines if a file is placed or removed
+	// exception to this is the cloud-config file, as it is valid being empty (for example, when only specifying the aws cloudprovider and no additional config)
+	if fileContents != "" || fileName == cloudConfigFileName {
 		containerEnv = []string{ConfigEnv + "=" + fileContents}
 		cmd = []string{
 			"sh",


### PR DESCRIPTION
https://github.com/rancher/rke/issues/1805

Considerations taken:
- Rewrite logic to not have cloud config if there is no additional config besides configuring the cloud provider: this will affect code in more than one place, this will also affect all existing clusters as a flag removed will trigger updates on most of the k8s containers/components and should not be in a patch release.
- The file will not be removed in this logic: we dont support switching cloud provider and there is no valid use case to have it removed besides that