### PR TITLE
Fix always show certificates are about to expire issue

### DIFF
--- a/pki/services_test.go
+++ b/pki/services_test.go
@@ -1,0 +1,142 @@
+package pki
+
+import (
+	"context"
+	"github.com/rancher/rke/hosts"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+func TestDeleteUnusedCerts(t *testing.T) {
+	tests := []struct {
+		ctx             context.Context
+		name            string
+		certs           map[string]CertificatePKI
+		certName        string
+		hosts           []*hosts.Host
+		expectLeftCerts map[string]CertificatePKI
+	}{
+		{
+			ctx:  context.Background(),
+			name: "Keep valid etcd certs",
+			certs: map[string]CertificatePKI{
+				"kube-etcd-172-17-0-3":    CertificatePKI{},
+				"kube-etcd-172-17-0-4":    CertificatePKI{},
+				"kube-node":               CertificatePKI{},
+				"kube-kubelet-172-17-0-4": CertificatePKI{},
+				"kube-apiserver":          CertificatePKI{},
+				"kube-proxy":              CertificatePKI{},
+			},
+			certName: EtcdCertName,
+			hosts: []*hosts.Host{
+				{RKEConfigNode: v3.RKEConfigNode{
+					Address: "172.17.0.3",
+				}},
+				{RKEConfigNode: v3.RKEConfigNode{
+					Address: "172.17.0.4",
+				}},
+			},
+			expectLeftCerts: map[string]CertificatePKI{
+				"kube-etcd-172-17-0-3":    CertificatePKI{},
+				"kube-etcd-172-17-0-4":    CertificatePKI{},
+				"kube-node":               CertificatePKI{},
+				"kube-kubelet-172-17-0-4": CertificatePKI{},
+				"kube-apiserver":          CertificatePKI{},
+				"kube-proxy":              CertificatePKI{},
+			},
+		},
+		{
+			ctx:  context.Background(),
+			name: "Keep valid kubelet certs",
+			certs: map[string]CertificatePKI{
+				"kube-kubelet-172-17-0-5": CertificatePKI{},
+				"kube-kubelet-172-17-0-6": CertificatePKI{},
+				"kube-node":               CertificatePKI{},
+				"kube-apiserver":          CertificatePKI{},
+				"kube-proxy":              CertificatePKI{},
+				"kube-etcd-172-17-0-6":    CertificatePKI{},
+			},
+			certName: KubeletCertName,
+			hosts: []*hosts.Host{
+				{RKEConfigNode: v3.RKEConfigNode{
+					Address: "172.17.0.5",
+				}},
+				{RKEConfigNode: v3.RKEConfigNode{
+					Address: "172.17.0.6",
+				}},
+			},
+			expectLeftCerts: map[string]CertificatePKI{
+				"kube-kubelet-172-17-0-5": CertificatePKI{},
+				"kube-kubelet-172-17-0-6": CertificatePKI{},
+				"kube-node":               CertificatePKI{},
+				"kube-apiserver":          CertificatePKI{},
+				"kube-proxy":              CertificatePKI{},
+				"kube-etcd-172-17-0-6":    CertificatePKI{},
+			},
+		},
+		{
+			ctx:  context.Background(),
+			name: "Remove unused etcd certs",
+			certs: map[string]CertificatePKI{
+				"kube-etcd-172-17-0-11":    CertificatePKI{},
+				"kube-etcd-172-17-0-10":    CertificatePKI{},
+				"kube-kubelet-172-17-0-11": CertificatePKI{},
+				"kube-node":                CertificatePKI{},
+				"kube-apiserver":           CertificatePKI{},
+				"kube-proxy":               CertificatePKI{},
+			},
+			certName: EtcdCertName,
+			hosts: []*hosts.Host{
+				{RKEConfigNode: v3.RKEConfigNode{
+					Address: "172.17.0.11",
+				}},
+				{RKEConfigNode: v3.RKEConfigNode{
+					Address: "172.17.0.12",
+				}},
+			},
+			expectLeftCerts: map[string]CertificatePKI{
+				"kube-etcd-172-17-0-11":    CertificatePKI{},
+				"kube-kubelet-172-17-0-11": CertificatePKI{},
+				"kube-node":                CertificatePKI{},
+				"kube-apiserver":           CertificatePKI{},
+				"kube-proxy":               CertificatePKI{},
+			},
+		},
+		{
+			ctx:  context.Background(),
+			name: "Remove unused kubelet certs",
+			certs: map[string]CertificatePKI{
+				"kube-kubelet-172-17-0-11": CertificatePKI{},
+				"kube-kubelet-172-17-0-10": CertificatePKI{},
+				"kube-etcd-172-17-0-10":    CertificatePKI{},
+				"kube-node":                CertificatePKI{},
+				"kube-apiserver":           CertificatePKI{},
+				"kube-proxy":               CertificatePKI{},
+			},
+			certName: KubeletCertName,
+			hosts: []*hosts.Host{
+				{RKEConfigNode: v3.RKEConfigNode{
+					Address: "172.17.0.11",
+				}},
+				{RKEConfigNode: v3.RKEConfigNode{
+					Address: "172.17.0.12",
+				}},
+			},
+			expectLeftCerts: map[string]CertificatePKI{
+				"kube-kubelet-172-17-0-11": CertificatePKI{},
+				"kube-etcd-172-17-0-10":    CertificatePKI{},
+				"kube-node":                CertificatePKI{},
+				"kube-apiserver":           CertificatePKI{},
+				"kube-proxy":               CertificatePKI{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deleteUnusedCerts(tt.ctx, tt.certs, tt.certName, tt.hosts)
+			assert.Equal(t, true, reflect.DeepEqual(tt.certs, tt.expectLeftCerts))
+		})
+	}
+}


### PR DESCRIPTION
Problem: 

The ETCD certs of removed hosts will not be removed or rotated. 
API/UI will always show there are certs expired in this cluster even all needed certs are rotated.
In the screenshot, the highlight etcd host has been removed from the cluster.

So users will always see the certificates expire warning in Rancher

![image](https://user-images.githubusercontent.com/21168270/70685660-07aba780-1ce5-11ea-8770-3bd111908b2d.png)

![image](https://user-images.githubusercontent.com/21168270/70685688-1abe7780-1ce5-11ea-9137-6c60a976b0d3.png)

Solution: 

Delete the unused ETCD certs when rotating certs

Related Rancher PR:

https://github.com/rancher/rancher/pull/24548

Issue: 

https://github.com/rancher/rancher/issues/24333