### PR TITLE
Remove the prefixPath from the /lib/modules bind mount for kube-proxy IPVS support

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -651,7 +651,7 @@ func (c *Cluster) BuildKubeProxyProcess(host *hosts.Host, prefixPath string, svc
 	Binds := []string{
 		fmt.Sprintf("%s:/etc/kubernetes:z", path.Join(prefixPath, "/etc/kubernetes")),
 		"/run:/run",
-		fmt.Sprintf("%s:/lib/modules:z,ro", path.Join(prefixPath, "/lib/modules")),
+		"/lib/modules:/lib/modules:z,ro",
 	}
 	if host.DockerInfo.OSType == "windows" { // compatible with Windows
 		Binds = []string{


### PR DESCRIPTION
Change to not consider the prefixPath for the /lib/modules bind mount in the kube-proxy container. Instead always bind mount /lib/modules to /lib/modules. I'm unaware of any systems that store their modules at a different path or at a minimum provide a symlink at /lib/modules to the actual path like /usr/lib/modules in the case of RancherOS.

#1823, where the bind mount pointed to /opt/rke/lib/modules on RancherOS.