### PR TITLE
Fix log output of full-cluster-state configmap name

### DIFF
--- a/cluster/state.go
+++ b/cluster/state.go
@@ -86,7 +86,7 @@ func SaveFullStateToKubernetes(ctx context.Context, kubeCluster *Cluster, fullSt
 				time.Sleep(time.Second * 5)
 				continue
 			}
-			log.Infof(ctx, "[state] Successfully Saved full cluster state to Kubernetes ConfigMap: %s", StateConfigMapName)
+			log.Infof(ctx, "[state] Successfully Saved full cluster state to Kubernetes ConfigMap: %s", FullStateConfigMapName)
 			timeout <- true
 			break
 		}


### PR DESCRIPTION
This PR corrects the log output during `rke up`.
The output still contains the legacy configmap name `cluster-state`. The new cluster state is saved in `full-cluster-state`.