### PR TITLE
Draining option added to the rke ujp

### DIFF
--- a/hosts/hosts.go
+++ b/hosts/hosts.go
@@ -161,9 +161,18 @@ func DeleteNode(ctx context.Context, toDeleteHost *Host, kubeClient *kubernetes.
 		return err
 
 	}
+
+
 	if err := k8s.CordonUncordon(kubeClient, toDeleteHost.HostnameOverride, true); err != nil {
 		return err
 	}
+
+	if err := k8s.DrainNode(kubeClient, toDeleteHost.HostnameOverride); err != nil {
+		return err
+	}
+	log.Infof(ctx, "Node draining ... : [%s] from the cluster", toDeleteHost.Address)
+
+
 	log.Infof(ctx, "[hosts] Deleting host [%s] from the cluster", toDeleteHost.Address)
 	if err := k8s.DeleteNode(kubeClient, toDeleteHost.HostnameOverride, cloudProvider); err != nil {
 		return err


### PR DESCRIPTION
Hello Rancher/RKE team,

I'm using RKE to manage the clusters. Rke up command is updating cluster fastly but there is something wrong on  upgrade and update progress I think .

RKE do not drain  the k8s nodes according to that this can cause down time .

Regarding to that I have added pod eviction option for rke . I want to test and improve these PR maybe we can improve all together. 

I will expect your feedbacks :D 

Thanks