### PR TITLE
Drop the log level to Debug since rancher can call this frequently

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -13,6 +13,7 @@ const (
 )
 
 type logger interface {
+	Debugf(msg string, args ...interface{})
 	Infof(msg string, args ...interface{})
 	Warnf(msg string, args ...interface{})
 }
@@ -36,4 +37,8 @@ func Infof(ctx context.Context, msg string, args ...interface{}) {
 
 func Warnf(ctx context.Context, msg string, args ...interface{}) {
 	getLogger(ctx).Warnf(msg, args...)
+}
+
+func Debugf(ctx context.Context, msg string, args ...interface{}) {
+	getLogger(ctx).Debugf(msg, args...)
 }

--- a/pki/services.go
+++ b/pki/services.go
@@ -491,7 +491,7 @@ func GenerateKubeletCertificate(ctx context.Context, certs map[string]Certificat
 	if caCrt == nil || caKey == nil {
 		return fmt.Errorf("CA Certificate or Key is empty")
 	}
-	log.Infof(ctx, "[certificates] Generating Kubernetes Kubelet certificates")
+	log.Debugf(ctx, "[certificates] Generating Kubernetes Kubelet certificates")
 	allHosts := hosts.NodesToHosts(rkeConfig.Nodes, "")
 	for _, host := range allHosts {
 		kubeletName := GetCrtNameForHost(host, KubeletCertName)
@@ -509,7 +509,7 @@ func GenerateKubeletCertificate(ctx context.Context, certs map[string]Certificat
 		if !rotate {
 			serviceKey = certs[kubeletName].Key
 		}
-		log.Infof(ctx, "[certificates] Generating %s certificate and key", kubeletName)
+		log.Debugf(ctx, "[certificates] Generating %s certificate and key", kubeletName)
 		kubeletCrt, kubeletKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, kubeletName, kubeletAltNames, serviceKey, nil)
 		if err != nil {
 			return err


### PR DESCRIPTION
When the parameter `generate_serving_certificate: true` is set on the cluster, rancher will regenerate kubelet certs every time worker agents connect back every ~2 mins. This is flooding the rancher logs in this case. Lowering the level to debug.

https://github.com/rancher/rancher/issues/24942