### PR TITLE
Allow addons.go to parse http and https ports for ingress controller

### DIFF
--- a/cluster/addons.go
+++ b/cluster/addons.go
@@ -62,6 +62,9 @@ type ingressOptions struct {
 	AlpineImage       string
 	IngressImage      string
 	IngressBackend    string
+	HTTPPort          int
+	HTTPSPort         int
+	NetworkMode       string
 	UpdateStrategy    *appsv1.DaemonSetUpdateStrategy
 }
 
@@ -565,6 +568,9 @@ func (c *Cluster) deployIngress(ctx context.Context, data map[string]interface{}
 		ExtraEnvs:         c.Ingress.ExtraEnvs,
 		ExtraVolumes:      c.Ingress.ExtraVolumes,
 		ExtraVolumeMounts: c.Ingress.ExtraVolumeMounts,
+		HTTPPort:          c.Ingress.HTTPPort,
+		HTTPSPort:         c.Ingress.HTTPSPort,
+		NetworkMode:       c.Ingress.NetworkMode,
 		UpdateStrategy: &appsv1.DaemonSetUpdateStrategy{
 			Type:          c.Ingress.UpdateStrategy.Strategy,
 			RollingUpdate: c.Ingress.UpdateStrategy.RollingUpdate,

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -514,6 +514,9 @@ func parseIngressConfig(clusterFile string, rkeConfig *v3.RancherKubernetesEngin
 	if err := parseIngressExtraVolumeMounts(ingressMap, rkeConfig); err != nil {
 		return err
 	}
+	if err := parseIngressDefaults(ingressMap, rkeConfig); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -595,6 +598,21 @@ func parseIngressExtraVolumeMounts(ingressMap map[string]interface{}, rkeConfig 
 		return fmt.Errorf("[parseIngressExtraVolumeMounts] error unmarshaling ingress config extraVolumeMounts: %v", err)
 	}
 	rkeConfig.Ingress.ExtraVolumeMounts = volumeMounts
+	return nil
+}
+
+func parseIngressDefaults(ingressMap map[string]interface{}, rkeConfig *v3.RancherKubernetesEngineConfig) error {
+	// Setting up default behaviour so as to not catch out
+	// existing users who use new version of RKE
+	if _, ok := ingressMap["network_mode"]; !ok {
+		rkeConfig.Ingress.NetworkMode = DefaultNetworkMode
+	}
+	if _, ok := ingressMap["http_port"]; !ok {
+		rkeConfig.Ingress.HTTPPort = DefaultHTTPPort
+	}
+	if _, ok := ingressMap["https_port"]; !ok {
+		rkeConfig.Ingress.HTTPSPort = DefaultHTTPSPort
+	}
 	return nil
 }
 

--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -89,6 +89,9 @@ const (
 	DefaultMaxUnavailableControlplane = "1"
 	DefaultNodeDrainTimeout           = 120
 	DefaultNodeDrainGracePeriod       = -1
+	DefaultHTTPPort                   = 80
+	DefaultHTTPSPort                  = 443
+	DefaultNetworkMode                = "hostNetwork"
 )
 
 var (

--- a/cluster/validation.go
+++ b/cluster/validation.go
@@ -177,6 +177,24 @@ func validateIngressOptions(c *Cluster) error {
 		return fmt.Errorf("DNSPolicy %s was not a valid DNS Policy", c.Ingress.DNSPolicy)
 	}
 
+	if c.Ingress.NetworkMode == "hostPort" {
+		if !(c.Ingress.HTTPPort >= 0 && c.Ingress.HTTPPort <= 65535) {
+			return fmt.Errorf("https port is invalid. Needs to be within 0 to 65535")
+		}
+		if !(c.Ingress.HTTPPort >= 0 && c.Ingress.HTTPPort <= 65535) {
+			return fmt.Errorf("http port is invalid. Needs to be within 0 to 65535")
+		}
+		if c.Ingress.HTTPPort != 0 && c.Ingress.HTTPSPort != 0 &&
+			(c.Ingress.HTTPPort == c.Ingress.HTTPSPort) {
+			return fmt.Errorf("http and https ports need to be different")
+		}
+	}
+
+	if !(c.Ingress.NetworkMode == "" ||
+		c.Ingress.NetworkMode == "hostNetwork" || c.Ingress.NetworkMode == "hostPort" ||
+		c.Ingress.NetworkMode == "none") {
+		return fmt.Errorf("NetworkMode %s was not a valid network mode", c.Ingress.NetworkMode)
+	}
 	return nil
 }
 

--- a/types/rke_types.go
+++ b/types/rke_types.go
@@ -415,6 +415,12 @@ type IngressConfig struct {
 	ExtraVolumeMounts []ExtraVolumeMount `yaml:"extra_volume_mounts" json:"extraVolumeMounts,omitempty" norman:"type=array[json]"`
 	// nginx daemonset upgrade strategy
 	UpdateStrategy *DaemonSetUpdateStrategy `yaml:"update_strategy" json:"updateStrategy,omitempty"`
+	// Http port for ingress controller daemonset
+	HTTPPort int `yaml:"http_port" json:"httpPort,omitempty"`
+	// Https port for ingress controller daemonset
+	HTTPSPort int `yaml:"https_port" json:"httpsPort,omitempty"`
+	// NetworkMode selector for ingress controller pods. Default is HostNetwork
+	NetworkMode string `yaml:"network_mode" json:"networkMode,omitempty"`
 }
 
 type ExtraEnv struct {


### PR DESCRIPTION
Minor tweak to allow addons.go to process the new fields introduced in IngressConfig for http and https ports to be passed to the nginx-ingress template available in kdm.

Related to issue: #1876 