### PR TITLE
Accept label to ignore nodes during upgrade

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -66,6 +66,8 @@ type Cluster struct {
 	WorkerHosts                      []*hosts.Host
 	EncryptionConfig                 encryptionConfig
 	NewHosts                         map[string]bool
+	MaxUnavailableForWorkerNodes     int
+	HostsLabeledToIgnoreUpgrade      map[string]bool
 }
 
 type encryptionConfig struct {
@@ -139,20 +141,32 @@ func (c *Cluster) DeployControlPlane(ctx context.Context, svcOptionData map[stri
 		}
 		return nil
 	}
-	if err := services.UpgradeControlPlane(ctx, kubeClient, c.ControlPlaneHosts,
+	inactiveHosts := make(map[string]bool)
+	var controlPlaneHosts []*hosts.Host
+	for _, host := range c.InactiveHosts {
+		if !c.HostsLabeledToIgnoreUpgrade[host.Address] {
+			inactiveHosts[host.HostnameOverride] = true
+		}
+	}
+	for _, host := range c.ControlPlaneHosts {
+		if !c.HostsLabeledToIgnoreUpgrade[host.Address] {
+			controlPlaneHosts = append(controlPlaneHosts, host)
+		}
+	}
+	if err := services.UpgradeControlPlaneNodes(ctx, kubeClient, controlPlaneHosts,
 		c.LocalConnDialerFactory,
 		c.PrivateRegistriesMap,
 		cpNodePlanMap,
 		c.UpdateWorkersOnly,
 		c.SystemImages.Alpine,
-		c.Certificates, c.UpgradeStrategy, c.NewHosts); err != nil {
+		c.Certificates, c.UpgradeStrategy, c.NewHosts, inactiveHosts); err != nil {
 		return fmt.Errorf("[controlPlane] Failed to upgrade Control Plane: %v", err)
 	}
 	return nil
 }
 
 func (c *Cluster) DeployWorkerPlane(ctx context.Context, svcOptionData map[string]*v3.KubernetesServicesOptions, reconcileCluster bool) (string, error) {
-	var workerOnlyHosts, multipleRolesHosts []*hosts.Host
+	var workerOnlyHosts, etcdAndWorkerHosts []*hosts.Host
 	kubeClient, err := k8s.NewClient(c.LocalKubeConfigPath, c.K8sWrapTransport)
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize new kubernetes client: %v", err)
@@ -161,12 +175,18 @@ func (c *Cluster) DeployWorkerPlane(ctx context.Context, svcOptionData map[strin
 	workerNodePlanMap := make(map[string]v3.RKEConfigNodePlan)
 	// Build cp node plan map
 	allHosts := hosts.GetUniqueHostList(c.EtcdHosts, c.ControlPlaneHosts, c.WorkerHosts)
-	for _, workerHost := range allHosts {
-		workerNodePlanMap[workerHost.Address] = BuildRKEConfigNodePlan(ctx, c, workerHost, workerHost.DockerInfo, svcOptionData)
-		if !workerHost.IsControl && !workerHost.IsEtcd {
-			workerOnlyHosts = append(workerOnlyHosts, workerHost)
+	for _, host := range allHosts {
+		workerNodePlanMap[host.Address] = BuildRKEConfigNodePlan(ctx, c, host, host.DockerInfo, svcOptionData)
+		if host.IsControl || c.HostsLabeledToIgnoreUpgrade[host.Address] {
+			continue
+		}
+		if !host.IsEtcd {
+			// separating hosts with only worker role so they undergo upgrade in maxUnavailable batches
+			workerOnlyHosts = append(workerOnlyHosts, host)
 		} else {
-			multipleRolesHosts = append(multipleRolesHosts, workerHost)
+			// separating nodes with etcd role, since at this point worker components in controlplane nodes are already upgraded by `UpgradeControlPlaneNodes`
+			// and these nodes will undergo upgrade of worker components sequentially
+			etcdAndWorkerHosts = append(etcdAndWorkerHosts, host)
 		}
 	}
 
@@ -182,13 +202,20 @@ func (c *Cluster) DeployWorkerPlane(ctx context.Context, svcOptionData map[strin
 		}
 		return "", nil
 	}
-	errMsgMaxUnavailableNotFailed, err := services.UpgradeWorkerPlane(ctx, kubeClient, multipleRolesHosts, workerOnlyHosts, c.InactiveHosts,
+
+	inactiveHosts := make(map[string]bool)
+	for _, host := range c.InactiveHosts {
+		if !c.HostsLabeledToIgnoreUpgrade[host.Address] {
+			inactiveHosts[host.HostnameOverride] = true
+		}
+	}
+	errMsgMaxUnavailableNotFailed, err := services.UpgradeWorkerPlaneForWorkerAndEtcdNodes(ctx, kubeClient, etcdAndWorkerHosts, workerOnlyHosts, inactiveHosts,
 		c.LocalConnDialerFactory,
 		c.PrivateRegistriesMap,
 		workerNodePlanMap,
 		c.Certificates,
 		c.UpdateWorkersOnly,
-		c.SystemImages.Alpine, c.UpgradeStrategy, c.NewHosts)
+		c.SystemImages.Alpine, c.UpgradeStrategy, c.NewHosts, c.MaxUnavailableForWorkerNodes)
 	if err != nil {
 		return "", fmt.Errorf("[workerPlane] Failed to upgrade Worker Plane: %v", err)
 	}
@@ -473,6 +500,7 @@ func InitClusterObject(ctx context.Context, rkeConfig *v3.RancherKubernetesEngin
 		EncryptionConfig: encryptionConfig{
 			EncryptionProviderFile: encryptConfig,
 		},
+		HostsLabeledToIgnoreUpgrade: make(map[string]bool),
 	}
 	if metadata.K8sVersionToRKESystemImages == nil {
 		metadata.InitMetadata(ctx)

--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -200,7 +200,7 @@ func (c *Cluster) setClusterDefaults(ctx context.Context, flags ExternalFlags) e
 
 func (c *Cluster) setNodeUpgradeStrategy() {
 	if c.UpgradeStrategy == nil {
-		logrus.Info("No input provided for maxUnavailable, setting it to default value of 10%")
+		logrus.Infof("No input provided for maxUnavailable, setting it to default value of %v", DefaultMaxUnavailable)
 		c.UpgradeStrategy = &v3.NodeUpgradeStrategy{
 			MaxUnavailable: DefaultMaxUnavailable,
 		}

--- a/k8s/node.go
+++ b/k8s/node.go
@@ -14,12 +14,13 @@ import (
 )
 
 const (
-	HostnameLabel             = "kubernetes.io/hostname"
-	InternalAddressAnnotation = "rke.cattle.io/internal-ip"
-	ExternalAddressAnnotation = "rke.cattle.io/external-ip"
-	AWSCloudProvider          = "aws"
-	MaxRetries                = 5
-	RetryInterval             = 5
+	HostnameLabel                = "kubernetes.io/hostname"
+	InternalAddressAnnotation    = "rke.cattle.io/internal-ip"
+	ExternalAddressAnnotation    = "rke.cattle.io/external-ip"
+	IgnoreHostDuringUpgradeLabel = "rke.cattle.io/ignore-during-upgrade"
+	AWSCloudProvider             = "aws"
+	MaxRetries                   = 5
+	RetryInterval                = 5
 )
 
 func DeleteNode(k8sClient *kubernetes.Clientset, nodeName, cloudProvider string) error {


### PR DESCRIPTION
RKE does a cluster scan to find the unreachable hosts, and if that number
is same as or exceeds maxUnavailable, upgrade won't proceed.
This commit introduces a label users can provide for their nodes so they
don't get counted as unavailable and are excluded from upgrade.
This commit also includes a couple of bug fixes:
1. When maxUnavailable was provided as a percentage, I was including only the active hosts in the calculation, whereas inactive hosts should be included too. So if from 5 worker hosts 1 is inactive and maxUnavailable is 40%, I was calculating maxUnavailable number as 40% of 4, instead of 40% of 5. Changed this to include all hosts  
2. When upgrading any node, I first check all nodes in the cluster to see if any previously upgraded hosts became inactive, I was listing them using kubectl get nodes. This returned the inactive hosts also but in NotReady state. We don’t need to check the status of Inactive hosts since they’re not considered part of cluster. And we already determine before upgrade starts if number of inactive hosts >= maxUnavailable  
3. The check mentioned above returns all nodes. So if I’m upgrading controlplane nodes, it will also return nodes with only worker role. And we don’t need to check their status when controlplane nodes are getting upgraded. So now I’m using only those nodes from kubectl get nodes output that belong to the current set of nodes being upgraded  
4. Upgrading controlplane and worker components in one go for control nodes

Issue tracking labels enhancement: https://github.com/rancher/rke/issues/1906
Bugs fixed: 
https://github.com/rancher/rke/issues/1909
https://github.com/rancher/rke/issues/1907
https://github.com/rancher/rke/issues/1908

https://github.com/rancher/rancher/issues/25480
Also adds fix to cordon/drain control nodes only once during upgrade by combining upgrade of controlplane and worker components