### PR TITLE
lock to avoid concurrent map writes

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -36,9 +37,12 @@ var (
 	c = http.Client{
 		Timeout: time.Second * 30,
 	}
+	kdmMutex = sync.Mutex{}
 )
 
 func InitMetadata(ctx context.Context) error {
+	kdmMutex.Lock()
+	defer kdmMutex.Unlock()
 	data, err := loadData()
 	if err != nil {
 		return fmt.Errorf("failed to load data.json, error: %v", err)


### PR DESCRIPTION
panic from logs
```
2020/02/28 13:36:17 [INFO] Refreshing driverMetadata in 1440 minutes
fatal error: concurrent map writes

goroutine 14406 [running]:
runtime.throw(0x4a02e62, 0x15)
	/usr/local/go/src/runtime/panic.go:774 +0x72 fp=0xc001a43718 sp=0xc001a436e8 pc=0x10317f2
runtime.mapassign(0x4107d60, 0xc00b28e2a0, 0xc001a43810, 0x12)
	/usr/local/go/src/runtime/map.go:588 +0x5c3 fp=0xc001a437a0 sp=0xc001a43718 pc=0x1010c03
github.com/rancher/rke/metadata.initK8sRKESystemImages(0xc00ace2180, 0xc00ace3a70, 0xc00ace3aa0, 0xc00b132270, 0xc00b1322a0, 0xc00b1322d0, 0xc00b132300, 0xc00b132330, 0xc00b132510, 0xc00b132540, ...)
	/Users/kshah/go/pkg/mod/github.com/rancher/rke@v1.1.0-rc8/metadata/metadata.go:129 +0x42a fp=0xc001a44368 sp=0xc001a437a0 pc=0x2c64e7a
github.com/rancher/rke/metadata.InitMetadata(0x5222b40, 0xc000054078, 0x0, 0x0)
	/Users/kshah/go/pkg/mod/github.com/rancher/rke@v1.1.0-rc8/metadata/metadata.go:46 +0x114 fp=0xc001a44550 sp=0xc001a44368 pc=0x2c64164
github.com/rancher/rke/cluster.InitClusterObject(0x5222b40, 0xc000054078, 0xc001a450b0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)

```


https://github.com/rancher/rancher/issues/25583