### PR TITLE
Add flag to enable TRACE logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,11 +32,17 @@ func mainErr() error {
 	app.Version = VERSION
 	app.Usage = "Rancher Kubernetes Engine, an extremely simple, lightning fast Kubernetes installer that works everywhere"
 	app.Before = func(ctx *cli.Context) error {
-		if ctx.GlobalBool("debug") {
-			logrus.SetLevel(logrus.DebugLevel)
-		}
 		if ctx.GlobalBool("quiet") {
 			logrus.SetOutput(ioutil.Discard)
+		} else {
+			if ctx.GlobalBool("debug") {
+				logrus.SetLevel(logrus.DebugLevel)
+				logrus.Debugf("Loglevel set to [%v]", logrus.DebugLevel)
+			}
+			if ctx.GlobalBool("trace") {
+				logrus.SetLevel(logrus.TraceLevel)
+				logrus.Tracef("Loglevel set to [%v]", logrus.TraceLevel)
+			}
 		}
 		if released.MatchString(app.Version) {
 			metadata.RKEVersion = app.Version
@@ -64,6 +70,10 @@ func mainErr() error {
 		cli.BoolFlag{
 			Name:  "quiet,q",
 			Usage: "Quiet mode, disables logging and only critical output will be printed",
+		},
+		cli.BoolFlag{
+			Name:  "trace",
+			Usage: "Trace logging",
 		},
 	}
 	return app.Run(os.Args)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/24994

I've tried to think of a couple of ways to do this:

- Implement a loglevel flag and try to keep `--debug` and `--quiet`, and offer a new loglevel flag. But the new loglevel flag would only serve the new TRACE level, because we are not offering any per level logging. It's debug or quiet (or TRACE after this) so there is no real point in having a separate flag.
- Adding trace flag as below seems to be not bad, it's a global level flag and it is an exception to use it (TRACE will be logging everything, including sensitive info), so having a specific flag to enable it should be OK. I didn't include a shorthand for it (`-t` or `-T` because it probably gets confusing and it's not that common for people to know what `-t` is and `-T` is maybe more common but then uppercase so probably confusing. As its an exception to use it, people probably want to use it written out to make sure they know what they are enabling.