### PR TITLE
Add support for zone and region in vSphere

### DIFF
--- a/templates/vsphere.go
+++ b/templates/vsphere.go
@@ -60,4 +60,12 @@ vm-name = "{{ .VsphereConfig.Global.VMName }}"
         {{- if ne .VsphereConfig.Network.PublicNetwork "" }}
         public-network = "{{ .VsphereConfig.Network.PublicNetwork }}"
         {{- end }}
+
+[Labels]
+        {{- if ne .VsphereConfig.Labels.Zone "" }}
+        zone = "{{ .VsphereConfig.Labels.Zone }}"
+        {{- end }}
+        {{- if ne .VsphereConfig.Labels.Region "" }}
+        region = "{{ .VsphereConfig.Labels.Region }}"
+        {{- end }}
 `


### PR DESCRIPTION
vSphere Cloud Provider added Zones support since Kubernetes version 1.14, and this PR adds the support for those in RKE.

https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/zones.html