### PR TITLE
Add logging structs/file content to trace loglevel

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -621,7 +621,7 @@ func parseNodeDrainInput(clusterFile string, rkeConfig *v3.RancherKubernetesEngi
 }
 
 func ParseConfig(clusterFile string) (*v3.RancherKubernetesEngineConfig, error) {
-	logrus.Debugf("Parsing cluster file [%v]", clusterFile)
+	logrus.Tracef("Parsing cluster file [%v]", clusterFile)
 	var rkeConfig v3.RancherKubernetesEngineConfig
 
 	// the customConfig is mapped to a k8s type, which doesn't unmarshal well because it has a

--- a/cluster/reconcile.go
+++ b/cluster/reconcile.go
@@ -28,7 +28,7 @@ const (
 )
 
 func ReconcileCluster(ctx context.Context, kubeCluster, currentCluster *Cluster, flags ExternalFlags, svcOptionData map[string]*v3.KubernetesServicesOptions) error {
-	logrus.Debugf("[reconcile] currentCluster: %+v\n", currentCluster)
+	logrus.Tracef("[reconcile] currentCluster: %+v\n", currentCluster)
 	log.Infof(ctx, "[reconcile] Reconciling cluster state")
 	kubeCluster.UpdateWorkersOnly = flags.UpdateOnly
 	if currentCluster == nil {

--- a/cluster/state.go
+++ b/cluster/state.go
@@ -190,7 +190,7 @@ func (s *FullState) WriteStateFile(ctx context.Context, statePath string) error 
 	if err != nil {
 		return fmt.Errorf("Failed to Marshal state object: %v", err)
 	}
-	logrus.Debugf("Writing state file: %s", stateFile)
+	logrus.Tracef("Writing state file: %s", stateFile)
 	if err := ioutil.WriteFile(statePath, stateFile, 0640); err != nil {
 		return fmt.Errorf("Failed to write state file: %v", err)
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -262,7 +262,7 @@ func pullImage(ctx context.Context, dClient *client.Client, hostname string, con
 			continue
 		}
 		defer out.Close()
-		if logrus.GetLevel() == logrus.DebugLevel {
+		if logrus.GetLevel() == logrus.TraceLevel {
 			io.Copy(os.Stdout, out)
 		} else {
 			io.Copy(ioutil.Discard, out)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -54,25 +55,26 @@ func InitMetadata(ctx context.Context) error {
 	return nil
 }
 
-// this method loads metadata from three place, if RANCHER_METADATA_URL is provided then load data from specified location. Otherwise load data from bindata.
+// this method loads metadata, if RANCHER_METADATA_URL is provided then load data from specified location. Otherwise load data from bindata.
 func loadData() (kdm.Data, error) {
 	var b []byte
 	var err error
 	u := os.Getenv(RancherMetadataURLEnv)
 	if u != "" {
-		logrus.Debugf("Loading data.json from %s, timestamp: %s", u, time.Now().Format(time.RFC822))
+		logrus.Debugf("Loading data.json from %s", u)
 		b, err = readFile(u)
 		if err != nil {
 			return kdm.Data{}, err
 		}
 	} else {
-		logrus.Debugf("Logging data.json from local source, timestamp: %s", time.Now().Format(time.RFC822))
+		logrus.Debug("Loading data.json from local source")
 		b, err = data.Asset("data/data.json")
 		if err != nil {
 			return kdm.Data{}, err
 		}
 	}
-	logrus.Debugf("data.json content: %v", string(b))
+	logrus.Debugf("data.json SHA256 checksum: %x", sha256.Sum256(b))
+	logrus.Tracef("data.json content: %v", string(b))
 	return kdm.FromData(b)
 }
 

--- a/pki/deploy.go
+++ b/pki/deploy.go
@@ -156,7 +156,8 @@ func DeployAdminConfig(ctx context.Context, kubeConfig, localConfigPath string) 
 	if len(kubeConfig) == 0 {
 		return nil
 	}
-	logrus.Debugf("Deploying admin Kubeconfig locally: %s", kubeConfig)
+	logrus.Debugf("Deploying admin Kubeconfig locally at [%s]", localConfigPath)
+	logrus.Tracef("Deploying admin Kubeconfig locally: %s", kubeConfig)
 	err := ioutil.WriteFile(localConfigPath, []byte(kubeConfig), 0640)
 	if err != nil {
 		return fmt.Errorf("Failed to create local admin kubeconfig file: %v", err)


### PR DESCRIPTION
Moves logging structs/file content to trace to keep debug readable.

Added log for `data.json` to show checksum to have a way to identify what file was retrieved/used.