### PR TITLE
MaxUnavailable and powered off hosts comparison

### DIFF
--- a/services/node_util.go
+++ b/services/node_util.go
@@ -115,7 +115,7 @@ func CalculateMaxUnavailable(maxUnavailableVal string, numHosts int, role string
 	return maxUnavailable, nil
 }
 
-func resetMaxUnavailable(maxUnavailable, lenInactiveHosts int, component string) (int, error) {
+func ResetMaxUnavailable(maxUnavailable, lenInactiveHosts int, component string) (int, error) {
 	if maxUnavailable > WorkerThreads {
 		/* upgrading a large number of nodes in parallel leads to a large number of goroutines, which has led to errors regarding too many open sockets
 		Because of this RKE switched to using workerpools. 50 workerthreads has been sufficient to optimize rke up, upgrading at most 50 nodes in parallel.

--- a/services/workerplane.go
+++ b/services/workerplane.go
@@ -55,10 +55,6 @@ func RunWorkerPlane(ctx context.Context, allHosts []*hosts.Host, localConnDialer
 func UpgradeWorkerPlaneForWorkerAndEtcdNodes(ctx context.Context, kubeClient *kubernetes.Clientset, mixedRolesHosts []*hosts.Host, workerOnlyHosts []*hosts.Host, inactiveHosts map[string]bool, localConnDialerFactory hosts.DialerFactory, prsMap map[string]v3.PrivateRegistry, workerNodePlanMap map[string]v3.RKEConfigNodePlan, certMap map[string]pki.CertificatePKI, updateWorkersOnly bool, alpineImage string, upgradeStrategy *v3.NodeUpgradeStrategy, newHosts map[string]bool, maxUnavailable int) (string, error) {
 	log.Infof(ctx, "[%s] Upgrading Worker Plane..", WorkerRole)
 	var errMsgMaxUnavailableNotFailed string
-	maxUnavailable, err := resetMaxUnavailable(maxUnavailable, len(inactiveHosts), WorkerRole)
-	if err != nil {
-		return errMsgMaxUnavailableNotFailed, err
-	}
 	updateNewHostsList(kubeClient, append(mixedRolesHosts, workerOnlyHosts...), newHosts)
 	if len(mixedRolesHosts) > 0 {
 		log.Infof(ctx, "First checking and processing worker components for upgrades on nodes with etcd role one at a time")


### PR DESCRIPTION
1. Compare maxUnavailable with powered off hosts before attempting to reconcile
NotReady hosts https://github.com/rancher/rancher/issues/25841
2. Include powered off hosts as failed hosts for controlplane upgrade to return error https://github.com/rancher/rancher/issues/25599
3. Change coredns upgrade strategy. With addons changes it was changed to have the k8s
default value for a deployment of 25% maxUnavailable and maxSurge. This commit changes it
back to maxUnavailable of 1 to avoid dns addon upgrade issues https://github.com/rancher/rke/issues/1944