### PR TITLE
Fix restoring backups when custom certs are used

### DIFF
--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -63,7 +63,20 @@ func EtcdCommand() cli.Command {
 			Usage: "Specify s3 folder name",
 		},
 	}
-	snapshotFlags = append(snapshotFlags, commonFlags...)
+
+	snapshotSaveFlags := append(snapshotFlags, commonFlags...)
+
+	snapshotRestoreFlags := []cli.Flag{
+		cli.StringFlag{
+			Name:  "cert-dir",
+			Usage: "Specify a certificate dir path",
+		},
+		cli.BoolFlag{
+			Name:  "custom-certs",
+			Usage: "Use custom certificates from a cert dir",
+		},
+	}
+	snapshotRestoreFlags = append(append(snapshotFlags, snapshotRestoreFlags...), commonFlags...)
 
 	return cli.Command{
 		Name:  "etcd",
@@ -72,13 +85,13 @@ func EtcdCommand() cli.Command {
 			{
 				Name:   "snapshot-save",
 				Usage:  "Take snapshot on all etcd hosts",
-				Flags:  snapshotFlags,
+				Flags:  snapshotSaveFlags,
 				Action: SnapshotSaveEtcdHostsFromCli,
 			},
 			{
 				Name:   "snapshot-restore",
 				Usage:  "Restore existing snapshot",
-				Flags:  snapshotFlags,
+				Flags:  snapshotRestoreFlags,
 				Action: RestoreEtcdSnapshotFromCli,
 			},
 		},
@@ -230,6 +243,9 @@ func RestoreEtcdSnapshotFromCli(ctx *cli.Context) error {
 	}
 	// setting up the flags
 	flags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	// Custom certificates and certificate dir flags
+	flags.CertificateDir = ctx.String("cert-dir")
+	flags.CustomCerts = ctx.Bool("custom-certs")
 
 	_, _, _, _, _, err = RestoreEtcdSnapshot(context.Background(), rkeConfig, hosts.DialersOptions{}, flags, map[string]interface{}{}, etcdSnapshotName)
 	return err


### PR DESCRIPTION
Before this change, `rke etcd snapshot-restore` did not support `--custom-certs` and `--cert-dir` flags. As a result, an attempt to restore snapshot on cluster using custom certificates resulted in fatal error:

```
FATA[0032] CA Certificate or Key is empty
```

This commit adds `--custom-certs` and `--cert-dir` flag handling similar to `rke up` command, resolving the issue.