### PR TITLE
Validate kube-ca cert before rotating certs

### DIFF
--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -2,10 +2,9 @@ package cmd
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"time"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/rancher/rke/cluster"
 	"github.com/rancher/rke/hosts"
@@ -14,6 +13,7 @@ import (
 	"github.com/rancher/rke/pki/cert"
 	"github.com/rancher/rke/services"
 	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -236,6 +236,21 @@ func rotateRKECertificates(ctx context.Context, kubeCluster *cluster.Cluster, fl
 		return nil, fmt.Errorf("Failed to rotate certificates: can't find old certificates")
 	}
 	currentCluster.RotateCertificates = kubeCluster.RotateCertificates
+	if !kubeCluster.RotateCertificates.CACertificates {
+		caCertPKI, ok := rkeFullState.CurrentState.CertificatesBundle[pki.CACertName]
+		if !ok {
+			return nil, fmt.Errorf("Failed to rotate certificates: can't find CA certificate")
+		}
+		caCert := caCertPKI.Certificate
+		if caCert == nil {
+			return nil, fmt.Errorf("Failed to rotate certificates: CA certificate is nil")
+		}
+		certPool := x509.NewCertPool()
+		certPool.AddCert(caCert)
+		if _, err := caCert.Verify(x509.VerifyOptions{Roots: certPool, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}}); err != nil {
+			return nil, fmt.Errorf("Failed to rotate certificates: CA certificate is invalid, please use the --rotate-ca flag to rotate CA certificate, error: %v", err)
+		}
+	}
 	if err := cluster.RotateRKECertificates(ctx, currentCluster, flags, rkeFullState); err != nil {
 		return nil, err
 	}

--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -206,6 +206,7 @@ func validateCerts(state cluster.State) error {
 			} else {
 				failedErrs = errors.Wrap(failedErrs, fmt.Sprintf("Certificate [%s] is nil", certPKI.Name))
 			}
+			continue
 		}
 
 		certPool := x509.NewCertPool()


### PR DESCRIPTION
https://github.com/rancher/rke/issues/1974

Problem: `rke cert rotate` rotates all certificates, but it rotates the kube-ca cert only if the flag 
`--rotate-ca` is used. RKE rotates certs even if kube-ca has expired, and expired kube-ca shouldn't be generating certs. 
Solution: RKE shouldn't rotate certs if `--rotate-ca` is not passed to `rke cert rotate` without checking the expiration of kube-ca
