### PR TITLE
Remove user addons when not present

### DIFF
--- a/addons/addons.go
+++ b/addons/addons.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rancher/rke/k8s"
 	"github.com/rancher/rke/templates"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -25,7 +26,9 @@ func getAddonJob(addonName, nodeName, image string, isDelete bool) (string, erro
 		"Image":     image,
 		"DeleteJob": strconv.FormatBool(isDelete),
 	}
-	return templates.CompileTemplateFromMap(templates.AddonJobTemplate, jobConfig)
+	template, err := templates.CompileTemplateFromMap(templates.AddonJobTemplate, jobConfig)
+	logrus.Tracef("template for [%s] is: [%s]", addonName, template)
+	return template, err
 }
 
 func AddonJobExists(addonJobName, kubeConfigPath string, k8sWrapTransport transport.WrapperFunc) (bool, error) {

--- a/templates/addonjob.go
+++ b/templates/addonjob.go
@@ -42,7 +42,7 @@ spec:
             image: {{$image}}
             {{- if eq .DeleteJob "true" }}
             command: ["/bin/sh"]
-            args: ["-c" ,"kubectl get --ignore-not-found=true -f /etc/config/{{$addonName}}.yaml -o name | xargs kubectl delete --ignore-not-found=true"]
+            args: ["-c" ,"kubectl get --ignore-not-found=true -f /etc/config/{{$addonName}}.yaml -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,KIND:.kind --no-headers | while read name namespace kind; do if [ "x${namespace}" = "x<none>" ]; then echo kubectl delete $kind $name; else echo kubectl -n $namespace delete $kind $name; fi; done"]
             {{- else }}
             command: [ "kubectl", "apply", "-f" , "/etc/config/{{$addonName}}.yaml"]
             {{- end }}


### PR DESCRIPTION
https://github.com/rancher/rke/issues/1916

This implements similar logic to configuring `provider: none` to monitoring/ingress, if there are no addons defined, check for the addon job and remove it. The logic that needed changing was that `-o name` provides you with `<kind>/<name>` which works for `kubectl delete` but it doesn't include namespace so resources in the non-default namespace (which is `kube-system`) were not removed.

Example:

When deleting the `ingress` addon, the output of the command how it is today is:

```
kubectl get -f ingress.yaml -o name
namespace/ingress-nginx
configmap/nginx-configuration
configmap/tcp-services
configmap/udp-services
serviceaccount/nginx-ingress-serviceaccount
clusterrole.rbac.authorization.k8s.io/nginx-ingress-clusterrole
role.rbac.authorization.k8s.io/nginx-ingress-role
rolebinding.rbac.authorization.k8s.io/nginx-ingress-role-nisa-binding
clusterrolebinding.rbac.authorization.k8s.io/nginx-ingress-clusterrole-nisa-binding
daemonset.apps/nginx-ingress-controller
deployment.apps/default-http-backend
service/default-http-backend
```

Which wouldn't work if we didn't include the namespace in there, as all the resource are being deleted are not deleted in the namespace but because the namespace is in there, everything gets deleted and the rest is ignored (``--ignore-not-found=true`).

For the other addons, they are in `kube-system` which is the default namespace for `kubectl` commands so that also works.

For the user addons, the namespace resource will not always be in the definition and without it, it cannot be deleted (as it defaults to `kube-system` and might be created in `default` or basically wherever. The output for addons how it is today:

```
pod/nginx
```

Which does not include the namespace. The fix is to list all parameters needed to properly delete them (and exclude namespace parameter if namespace is `<none>` (not namespaced)):

```
kubectl delete Namespace ingress-nginx                                                                                                                         
kubectl -n ingress-nginx delete ConfigMap nginx-configuration                                                                                                  
kubectl -n ingress-nginx delete ConfigMap tcp-services                                                                                                                                                                                                                                                                        kubectl -n ingress-nginx delete ConfigMap udp-services  
kubectl -n ingress-nginx delete ServiceAccount nginx-ingress-serviceaccount                                                                                    
kubectl delete ClusterRole nginx-ingress-clusterrole                                                                                                           
kubectl -n ingress-nginx delete Role nginx-ingress-role                                                                                                        
kubectl -n ingress-nginx delete RoleBinding nginx-ingress-role-nisa-binding                                                                                    
kubectl delete ClusterRoleBinding nginx-ingress-clusterrole-nisa-binding                                                                                       
kubectl -n ingress-nginx delete DaemonSet nginx-ingress-controller                                                                                             
kubectl -n ingress-nginx delete Deployment default-http-backend                                                                                                
kubectl -n ingress-nginx delete Service default-http-backend                              
```

