### PR TITLE
[Backport] Retain user-configured dnsConfig fields when provider is not set

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -436,7 +436,9 @@ func (c *Cluster) setClusterDNSDefaults() error {
 		logrus.Debugf("Cluster version [%s] is less than version [%s], using DNS provider [%s]", clusterSemVer, K8sVersionCoreDNSSemVer, DefaultDNSProvider)
 		ClusterDNSProvider = DefaultDNSProvider
 	}
-	c.DNS = &v3.DNSConfig{}
+	if c.DNS == nil {
+		c.DNS = &v3.DNSConfig{}
+	}
 	c.DNS.Provider = ClusterDNSProvider
 	logrus.Debugf("DNS provider set to [%s]", ClusterDNSProvider)
 	return nil


### PR DESCRIPTION
We reset dns fields if provider isn't set, and that's removing nodelocal config too.
https://github.com/rancher/rke/issues/2014
Backporting https://github.com/rancher/rke/pull/1962 will prevent it