### PR TITLE
Revert "Add support for k8s 1.18"

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -718,11 +718,6 @@ func InitClusterObject(ctx context.Context, rkeConfig *v3.RancherKubernetesEngin
 	if len(c.CertificateDir) == 0 {
 		c.CertificateDir = GetCertificateDirPath(c.ConfigPath, c.ConfigDir)
 	}
-	// Setting cluster Defaults
-	err = c.setClusterDefaults(ctx, flags)
-	if err != nil {
-		return nil, err
-	}
 	// We don't manage custom configuration, if it's there we just use it.
 	if isEncryptionCustomConfig(rkeConfig) {
 		if c.EncryptionConfig.EncryptionProviderFile, err = c.readEncryptionCustomConfig(); err != nil {
@@ -734,6 +729,11 @@ func InitClusterObject(ctx context.Context, rkeConfig *v3.RancherKubernetesEngin
 		}
 	}
 
+	// Setting cluster Defaults
+	err = c.setClusterDefaults(ctx, flags)
+	if err != nil {
+		return nil, err
+	}
 	// extract cluster network configuration
 	if err = c.setNetworkOptions(); err != nil {
 		return nil, fmt.Errorf("failed set network options: %v", err)

--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -323,17 +323,6 @@ func (c *Cluster) setClusterServicesDefaults() {
 		}
 
 	}
-
-	enableEncryptionByDefault, err := checkVersionNeedsEncryptionDefault(c.Version)
-	if err != nil {
-		logrus.Warnf("Cannot determine if cluster version [%s] needs to have encryption enabled by default: %v", c.Version, err)
-	}
-	if enableEncryptionByDefault && c.Services.KubeAPI.SecretsEncryptionConfig == nil {
-		logrus.Debugf("Enabling encryption of secret data at rest by default for cluster version [%s]", c.Version)
-		c.Services.KubeAPI.SecretsEncryptionConfig = &v3.SecretsEncryptionConfig{
-			Enabled: true,
-		}
-	}
 	if c.Services.KubeAPI.AuditLog != nil &&
 		c.Services.KubeAPI.AuditLog.Enabled {
 		if c.Services.KubeAPI.AuditLog.Configuration == nil {
@@ -722,24 +711,5 @@ func checkVersionNeedsKubeAPIAuditLog(k8sVersion string) (bool, error) {
 		return true, nil
 	}
 	logrus.Debugf("Cluster version [%s] does not need to have kube-api audit log enabled", k8sVersion[1:])
-	return false, nil
-}
-
-func checkVersionNeedsEncryptionDefault(k8sVersion string) (bool, error) {
-	toMatch, err := semver.Make(k8sVersion[1:])
-	if err != nil {
-		return false, fmt.Errorf("Cluster version [%s] can not be parsed as semver", k8sVersion[1:])
-	}
-	logrus.Debugf("Checking if cluster version [%s] needs to have encryption enabled by default", k8sVersion[1:])
-	// encryption turned on by default in k8s 1.18.0 and up
-	clusterDefaultEncryptionRange, err := semver.ParseRange(">=1.18.0-rancher0")
-	if err != nil {
-		return false, errors.New("Failed to parse semver range while checking if encryption is enabled by default")
-	}
-	if clusterDefaultEncryptionRange(toMatch) {
-		logrus.Debugf("Cluster version [%s] needs to have encryption enabled by default", k8sVersion[1:])
-		return true, nil
-	}
-	logrus.Debugf("Cluster version [%s] does not need to have encryption enabled by default", k8sVersion[1:])
 	return false, nil
 }


### PR DESCRIPTION
This reverts commit 763a896380c318fbef1825788e50528873c9976a.

(cherry picked from commit 6e194ab1a620182a10d32425b9c48dd9e2552b25)

Note:
don't need the other revert commit about rke version dev since already updated it to `1.1.2-rc0`