### PR TITLE
[0.2] set updateStrategy for nginx-ingress

### DIFF
--- a/templates/nginx-ingress.go
+++ b/templates/nginx-ingress.go
@@ -529,6 +529,10 @@ spec:
   selector:
     matchLabels:
       app: ingress-nginx
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
ingress daemonset in rke `0.2.10` had `apiVersion=extensions/v1beta1`
which defaults to `onDelete` strategy. We change apiVersion in new
template to `apps/v1`, but without explicitly changing the strategy,
it stays `onDelete`.

https://github.com/rancher/rancher/issues/27354