### PR TITLE
[2.4] Check ignoreDaemonsets for nil to avoid panic

### DIFF
--- a/services/node_util.go
+++ b/services/node_util.go
@@ -50,7 +50,7 @@ func cordonAndDrainNode(kubeClient *kubernetes.Clientset, host *hosts.Host, drai
 
 func getDrainHelper(kubeClient *kubernetes.Clientset, upgradeStrategy v3.NodeUpgradeStrategy) drain.Helper {
 	var ignoreDaemonSets bool
-	if upgradeStrategy.DrainInput == nil || *upgradeStrategy.DrainInput.IgnoreDaemonSets {
+	if upgradeStrategy.DrainInput == nil || upgradeStrategy.DrainInput.IgnoreDaemonSets == nil || *upgradeStrategy.DrainInput.IgnoreDaemonSets {
 		ignoreDaemonSets = true
 	}
 	drainHelper := drain.Helper{


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/27618

IgnoreDaemonSets was made a pointer for some terraform changes, and panics when it's not checked for nil before dereferencing