### PR TITLE
Change Default Addon Job Timeout to 45s

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -14,7 +14,7 @@ import (
 const (
 	DefaultRetries          = 5
 	DefaultSleepSeconds     = 5
-	DefaultTimeout          = 30
+	DefaultTimeout          = 45
 	K8sWrapTransportTimeout = 30
 )
 


### PR DESCRIPTION
In recent tickets, I have seen the rke-network-job in vSphere clusters has failed as it has timed out after just 30s at its default value. (Usually at 31-32s)

Increasing the addon timeout has worked to resolve this per customer but this change should be introduced so that in future other customers do not see this.

In a recent ticket, we tried 60s but seemed excessive from our testing so 45s should be a reasonable compromise.

If this change needs to be extended anywhere else in the code base please let me know

gz#10699
gz#9105