### PR TITLE
Able to include and extract state file in snapshot

### DIFF
--- a/cluster/state.go
+++ b/cluster/state.go
@@ -228,6 +228,19 @@ func GetCertificateDirPath(configPath, configDir string) string {
 	return trimmedName + certDirExt
 }
 
+func StringToFullState(ctx context.Context, stateFileContent string) (*FullState, error) {
+	rkeFullState := &FullState{}
+	logrus.Tracef("stateFileContent: %s", stateFileContent)
+	if err := json.Unmarshal([]byte(stateFileContent), rkeFullState); err != nil {
+		return rkeFullState, err
+	}
+	rkeFullState.DesiredState.CertificatesBundle = pki.TransformPEMToObject(rkeFullState.DesiredState.CertificatesBundle)
+	rkeFullState.CurrentState.CertificatesBundle = pki.TransformPEMToObject(rkeFullState.CurrentState.CertificatesBundle)
+	logrus.Tracef("rkeFullState: %+v", rkeFullState)
+
+	return rkeFullState, nil
+}
+
 func ReadStateFile(ctx context.Context, statePath string) (*FullState, error) {
 	rkeFullState := &FullState{}
 	fp, err := filepath.Abs(statePath)

--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -107,6 +107,10 @@ func SnapshotSaveEtcdHosts(
 	flags cluster.ExternalFlags, snapshotName string) error {
 
 	log.Infof(ctx, "Starting saving snapshot on etcd hosts")
+
+	stateFilePath := cluster.GetStateFilePath(flags.ClusterFilePath, flags.ConfigDir)
+	rkeFullState, _ := cluster.ReadStateFile(ctx, stateFilePath)
+
 	kubeCluster, err := cluster.InitClusterObject(ctx, rkeConfig, flags, "")
 	if err != nil {
 		return err
@@ -116,6 +120,10 @@ func SnapshotSaveEtcdHosts(
 	}
 
 	if err := kubeCluster.TunnelHosts(ctx, flags); err != nil {
+		return err
+	}
+
+	if err := kubeCluster.DeployStateFile(ctx, rkeFullState, snapshotName); err != nil {
 		return err
 	}
 
@@ -135,10 +143,43 @@ func RestoreEtcdSnapshot(
 	data map[string]interface{},
 	snapshotName string) (string, string, string, string, map[string]pki.CertificatePKI, error) {
 	var APIURL, caCrt, clientCert, clientKey string
-	log.Infof(ctx, "Restoring etcd snapshot %s", snapshotName)
 
+	log.Infof(ctx, "Checking if state file is included in snapshot file for %s", snapshotName)
+	// Creating temp cluster to check if snapshot archive contains statefile and retrieve it
+	tempCluster, err := cluster.InitClusterObject(ctx, rkeConfig, flags, "")
+	if err != nil {
+		return APIURL, caCrt, clientCert, clientKey, nil, err
+	}
+	if err := tempCluster.SetupDialers(ctx, dialersOptions); err != nil {
+		return APIURL, caCrt, clientCert, clientKey, nil, err
+	}
+	if err := tempCluster.TunnelHosts(ctx, flags); err != nil {
+		return APIURL, caCrt, clientCert, clientKey, nil, err
+	}
+
+	rkeFullState := &cluster.FullState{}
+	stateFileRetrieved := false
+
+	// Local state file
 	stateFilePath := cluster.GetStateFilePath(flags.ClusterFilePath, flags.ConfigDir)
-	rkeFullState, _ := cluster.ReadStateFile(ctx, stateFilePath)
+	// Extract state file from snapshot
+	stateFile, err := tempCluster.GetStateFileFromSnapshot(ctx, snapshotName)
+	// If state file is not in snapshot (or can't be retrieved), fallback to local state file
+	if err != nil {
+		logrus.Infof("Could not extract state file from snapshot [%s] on any host, falling back to local state file: %v", snapshotName, err)
+		rkeFullState, _ = cluster.ReadStateFile(ctx, stateFilePath)
+	} else {
+		// Parse extracted statefile to FullState struct
+		rkeFullState, err = cluster.StringToFullState(ctx, stateFile)
+		if err != nil {
+			logrus.Errorf("Error when converting state file contents to rkeFullState: %v", err)
+			return APIURL, caCrt, clientCert, clientKey, nil, err
+		}
+		logrus.Infof("State file is successfully extracted from snapshot [%s]", snapshotName)
+		stateFileRetrieved = true
+	}
+
+	log.Infof(ctx, "Restoring etcd snapshot %s", snapshotName)
 
 	kubeCluster, err := cluster.InitClusterObject(ctx, rkeConfig, flags, rkeFullState.DesiredState.EncryptionConfig)
 	if err != nil {
@@ -149,8 +190,11 @@ func RestoreEtcdSnapshot(
 		return APIURL, caCrt, clientCert, clientKey, nil, err
 	}
 
-	if err := checkLegacyCluster(ctx, kubeCluster, rkeFullState, flags); err != nil {
-		return APIURL, caCrt, clientCert, clientKey, nil, err
+	// If we can't retrieve statefile from snapshot, and we don't have local, we need to check for legacy cluster
+	if !stateFileRetrieved {
+		if err := checkLegacyCluster(ctx, kubeCluster, rkeFullState, flags); err != nil {
+			return APIURL, caCrt, clientCert, clientKey, nil, err
+		}
 	}
 
 	rkeFullState.CurrentState = cluster.State{}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -483,14 +483,24 @@ func WaitForContainer(ctx context.Context, dClient *client.Client, hostname stri
 			return 1, fmt.Errorf("Could not inspect container [%s] on host [%s]: %s", containerName, hostname, err)
 		}
 		if container.State.Running {
-			log.Infof(ctx, "Container [%s] is still running on host [%s]", containerName, hostname)
+			stderr, stdout, err := GetContainerLogsStdoutStderr(ctx, dClient, containerName, "1", false)
+			if err != nil {
+				logrus.Warnf("Failed to get container logs from container [%s] on host [%s]: %v", containerName, hostname, err)
+			}
+
+			log.Infof(ctx, "Container [%s] is still running on host [%s]: stderr: [%s], stdout: [%s]", containerName, hostname, stderr, stdout)
 			time.Sleep(1 * time.Second)
 			continue
 		}
 		logrus.Debugf("Exit code for [%s] container on host [%s] is [%d]", containerName, hostname, int64(container.State.ExitCode))
 		return int64(container.State.ExitCode), nil
 	}
-	return 1, fmt.Errorf("Container [%s] did not exit in time on host [%s]", containerName, hostname)
+	stderr, stdout, err := GetContainerLogsStdoutStderr(ctx, dClient, containerName, "1", false)
+	if err != nil {
+		logrus.Warnf("Failed to get container logs from container [%s] on host [%s]", containerName, hostname)
+	}
+
+	return 1, fmt.Errorf("Container [%s] did not exit in time on host [%s]: stderr: [%s], stdout: [%s]", containerName, hostname, stderr, stdout)
 }
 
 func IsContainerUpgradable(ctx context.Context, dClient *client.Client, imageCfg *container.Config, hostCfg *container.HostConfig, containerName string, hostname string, plane string) (bool, error) {

--- a/pki/constants.go
+++ b/pki/constants.go
@@ -3,7 +3,8 @@ package pki
 import "time"
 
 const (
-	CertPathPrefix          = "/etc/kubernetes/ssl/"
+	K8sBaseDir              = "/etc/kubernetes/"
+	CertPathPrefix          = K8sBaseDir + "ssl/"
 	CertificatesServiceName = "certificates"
 	CrtDownloaderContainer  = "cert-deployer"
 	CertFetcherContainer    = "cert-fetcher"
@@ -11,6 +12,7 @@ const (
 	TempCertPath            = "/etc/kubernetes/.tmp/"
 	ClusterConfig           = "cluster.yml"
 	ClusterStateFile        = "cluster-state.yml"
+	ClusterStateExt         = ".rkestate"
 	ClusterStateEnv         = "CLUSTER_STATE"
 	BundleCertPath          = "/backup/pki.bundle.tar.gz"
 

--- a/pki/deploy.go
+++ b/pki/deploy.go
@@ -53,19 +53,20 @@ func DeployCertificatesOnPlaneHost(ctx context.Context, host *hosts.Host, rkeCon
 	return doRunDeployer(ctx, host, env, certDownloaderImage, prsMap)
 }
 
-func DeployStateOnPlaneHost(ctx context.Context, host *hosts.Host, stateDownloaderImage string, prsMap map[string]v3.PrivateRegistry, clusterState string) error {
+func DeployStateOnPlaneHost(ctx context.Context, host *hosts.Host, stateDownloaderImage string, prsMap map[string]v3.PrivateRegistry, clusterState string, snapshotName string) error {
 	// remove existing container. Only way it's still here is if previous deployment failed
 	if err := docker.DoRemoveContainer(ctx, host.DClient, StateDeployerContainerName, host.Address); err != nil {
 		return err
 	}
 	containerEnv := []string{ClusterStateEnv + "=" + clusterState}
-	ClusterStateFilePath := path.Join(host.PrefixPath, TempCertPath, ClusterStateFile)
+	ClusterStateFilePath := path.Join(host.PrefixPath, K8sBaseDir, "/", fmt.Sprintf("%s%s", snapshotName, ClusterStateExt))
+	logrus.Debugf("[state] Deploying state to [%v] on node [%s]", ClusterStateFilePath, host.Address)
 	imageCfg := &container.Config{
 		Image: stateDownloaderImage,
 		Cmd: []string{
 			"sh",
 			"-c",
-			fmt.Sprintf("t=$(mktemp); echo -e \"$%s\" > $t && mv $t %s && chmod 644 %s", ClusterStateEnv, ClusterStateFilePath, ClusterStateFilePath),
+			fmt.Sprintf("t=$(mktemp); echo \"$%s\" > $t && mv $t %s && chmod 400 %s", ClusterStateEnv, ClusterStateFilePath, ClusterStateFilePath),
 		},
 		Env: containerEnv,
 	}

--- a/services/services.go
+++ b/services/services.go
@@ -35,6 +35,7 @@ const (
 	EtcdDownloadBackupContainerName = "etcd-download-backup"
 	EtcdServeBackupContainerName    = "etcd-Serve-backup"
 	EtcdChecksumContainerName       = "etcd-checksum-checker"
+	EtcdStateFileContainerName      = "etcd-extract-statefile"
 	NginxProxyContainerName         = "nginx-proxy"
 	SidekickContainerName           = "service-sidekick"
 	LogLinkContainerName            = "rke-log-linker"


### PR DESCRIPTION
In combination with https://github.com/rancher/rke-tools/pull/100

How this works for saving etcd snapshots:

- Added step that deploys the statefile
- In rke-tools, it will check if there is a state file present, and if yes, it will be included in the snapshot

How this works for restoring etcd snapshots:

- Setup a temporary cluster to create dialers to the nodes (because we dont have the state file)
- Try to extract the state file from the snapshot and read it
- If found, write it locally and use it to restore
- If not found, fall back to the local state file

Most of the decisions are token to keep backwards compatibility, mainly the steps of rke-tools checking if the state file is present, so even when newer versions are used, it will still successfully create a snapshot. For restoring, it will just error out if an older rke-tools image is used as the command to extract the state file is not recognized and will fall back to local file.

The following usecases were tested:

- Create and restore a snapshot created with these changes
- Create and restore a snapshot created with these changes and with the local `.rkestate` file removed
- Create a snapshot with an older version (without included statefile) and restore
- Create and restore a snapshot with the current RKE version and the new rke-tools image

