### PR TITLE
[v1.0] Use standard base64 encoding for Docker auth

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -699,7 +699,7 @@ func GetKubeletDockerConfig(prsMap map[string]v3.PrivateRegistry) (string, error
 	auths := map[string]authConfig{}
 
 	for url, pr := range prsMap {
-		auth := base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", pr.User, pr.Password)))
+		auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", pr.User, pr.Password)))
 		auths[url] = authConfig{Auth: auth}
 	}
 	cfg, err := json.Marshal(dockerConfig{auths})

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -45,3 +45,15 @@ func TestPrivateRegistry(t *testing.T) {
 	assert.Equal(t, a, a2)
 
 }
+
+func TestGetKubeletDockerConfig(t *testing.T) {
+	e := "{\"auths\":{\"https://registry.example.com\":{\"auth\":\"dXNlcjE6cGFzc3d+cmQ=\"}}}"
+	c, err := GetKubeletDockerConfig(map[string]v3.PrivateRegistry{
+		"https://registry.example.com": v3.PrivateRegistry{
+			User:     "user1",
+			Password: "passw~rd",
+		},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, c, e)
+}


### PR DESCRIPTION
Backport #2052

Original Issue - rancher/rancher#27029
Backport Issue - https://github.com/rancher/rancher/issues/28004