### PR TITLE
Use node label when cloudprovider is configured

### DIFF
--- a/k8s/node.go
+++ b/k8s/node.go
@@ -24,8 +24,8 @@ const (
 )
 
 func DeleteNode(k8sClient *kubernetes.Clientset, nodeName, cloudProvider string) error {
-
-	if cloudProvider == AWSCloudProvider {
+	// If cloud provider is configured, the node name can be set by the cloud provider, which can be different from the original node name
+	if cloudProvider != "" {
 		node, err := GetNode(k8sClient, nodeName)
 		if err != nil {
 			return err


### PR DESCRIPTION
When cloud provider is configured, the node name can be set by the cloud provider. If we don't account for this, the node cannot be found when we do cluster operation (for example, node delete)

https://github.com/rancher/rke/issues/2122