### PR TITLE
Add restore flag to use local state

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -120,6 +120,7 @@ type ExternalFlags struct {
 	GenerateCSR      bool
 	Local            bool
 	UpdateOnly       bool
+	UseLocalState    bool
 }
 
 func setDefaultIfEmptyMapValue(configMap map[string]string, key string, value string) {
@@ -606,13 +607,14 @@ func (c *Cluster) setCloudProvider() error {
 	return nil
 }
 
-func GetExternalFlags(local, updateOnly, disablePortCheck bool, configDir, clusterFilePath string) ExternalFlags {
+func GetExternalFlags(local, updateOnly, disablePortCheck, useLocalState bool, configDir, clusterFilePath string) ExternalFlags {
 	return ExternalFlags{
 		Local:            local,
 		UpdateOnly:       updateOnly,
 		DisablePortCheck: disablePortCheck,
 		ConfigDir:        configDir,
 		ClusterFilePath:  clusterFilePath,
+		UseLocalState:    useLocalState,
 	}
 }
 

--- a/cluster/state.go
+++ b/cluster/state.go
@@ -53,7 +53,7 @@ func (c *Cluster) GetClusterState(ctx context.Context, fullState *FullState) (*C
 	}
 
 	// resetup external flags
-	flags := GetExternalFlags(false, false, false, c.ConfigDir, c.ConfigPath)
+	flags := GetExternalFlags(false, false, false, false, c.ConfigDir, c.ConfigPath)
 	currentCluster, err := InitClusterObject(ctx, fullState.CurrentState.RancherKubernetesEngineConfig, flags, fullState.CurrentState.EncryptionConfig)
 	if err != nil {
 		return nil, err

--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -91,7 +91,7 @@ func rotateRKECertificatesFromCli(ctx *cli.Context) error {
 		return err
 	}
 	// setting up the flags
-	externalFlags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	externalFlags := cluster.GetExternalFlags(false, false, false, false, "", filePath)
 	// setting up rotate flags
 	rkeConfig.RotateCertificates = &v3.RotateCertificates{
 		CACertificates: rotateCACerts,
@@ -120,7 +120,7 @@ func generateCSRFromCli(ctx *cli.Context) error {
 		return err
 	}
 	// setting up the flags
-	externalFlags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	externalFlags := cluster.GetExternalFlags(false, false, false, false, "", filePath)
 	externalFlags.CertificateDir = ctx.String("cert-dir")
 	externalFlags.CustomCerts = ctx.Bool("custom-certs")
 

--- a/cmd/encryption.go
+++ b/cmd/encryption.go
@@ -55,7 +55,7 @@ func rotateEncryptionKeyFromCli(ctx *cli.Context) error {
 	}
 
 	// setting up the flags
-	flags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	flags := cluster.GetExternalFlags(false, false, false, false, "", filePath)
 
 	return RotateEncryptionKey(context.Background(), rkeConfig, hosts.DialersOptions{}, flags)
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -116,7 +116,7 @@ func clusterRemoveFromCli(ctx *cli.Context) error {
 	}
 
 	// setting up the flags
-	flags := cluster.GetExternalFlags(false, false, false, "", filePath)
+	flags := cluster.GetExternalFlags(false, false, false, false, "", filePath)
 
 	return ClusterRemove(context.Background(), rkeConfig, hosts.DialersOptions{}, flags)
 }
@@ -140,7 +140,7 @@ func clusterRemoveLocal(ctx *cli.Context) error {
 		return err
 	}
 	// setting up the flags
-	flags := cluster.GetExternalFlags(true, false, false, "", filePath)
+	flags := cluster.GetExternalFlags(true, false, false, false, "", filePath)
 
 	return ClusterRemove(context.Background(), rkeConfig, hosts.DialersOptions{}, flags)
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -288,7 +288,7 @@ func clusterUpFromCli(ctx *cli.Context) error {
 	updateOnly := ctx.Bool("update-only")
 	disablePortCheck := ctx.Bool("disable-port-check")
 	// setting up the flags
-	flags := cluster.GetExternalFlags(false, updateOnly, disablePortCheck, "", filePath)
+	flags := cluster.GetExternalFlags(false, updateOnly, disablePortCheck, false, "", filePath)
 	// Custom certificates and certificate dir flags
 	flags.CertificateDir = ctx.String("cert-dir")
 	flags.CustomCerts = ctx.Bool("custom-certs")
@@ -323,7 +323,7 @@ func clusterUpLocal(ctx *cli.Context) error {
 	// setting up the dialers
 	dialers := hosts.GetDialerOptions(nil, hosts.LocalHealthcheckFactory, nil)
 	// setting up the flags
-	flags := cluster.GetExternalFlags(true, false, false, "", filePath)
+	flags := cluster.GetExternalFlags(true, false, false, false, "", filePath)
 
 	if ctx.Bool("init") {
 		return ClusterInit(context.Background(), rkeConfig, dialers, flags)
@@ -349,7 +349,7 @@ func clusterUpDind(ctx *cli.Context) error {
 	// setting up the dialers
 	dialers := hosts.GetDialerOptions(hosts.DindConnFactory, hosts.DindHealthcheckConnFactory, nil)
 	// setting up flags
-	flags := cluster.GetExternalFlags(false, false, disablePortCheck, "", filePath)
+	flags := cluster.GetExternalFlags(false, false, disablePortCheck, false, "", filePath)
 	flags.DinD = true
 
 	if ctx.Bool("init") {


### PR DESCRIPTION
https://github.com/rancher/rke/issues/1336

This adds the flag `--use-local-state` for the `rke etcd restore-snapshot` command to use the local statefile and not check the snapshot archive for an included statefile