### PR TITLE
added windows path cleaner

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1119,7 +1119,7 @@ func (c *Cluster) GetHostInfoMap() map[string]types.Info {
 func (c *Cluster) getPrefixPath(os string) string {
 	switch {
 	case os == "windows" && c.WindowsPrefixPath != "":
-		return filepath.Clean(c.WindowsPrefixPath)
+		return util.CleanWindowsPath(c.WindowsPrefixPath)
 	default:
 		return filepath.Clean(c.PrefixPath)
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -161,3 +161,22 @@ func PrintProxyEnvVars() {
 		}
 	}
 }
+
+func CleanWindowsPath(s string) string {
+	// clean backslashes added from encoding
+	var new []string
+
+	// squash multi backslashes
+	sp := strings.Split(s, "\\")
+	for _, v := range sp {
+		if v != "" {
+			new = append(new, v)
+		}
+	}
+
+	// drive letter only, add a trailing slash
+	if len(new) == 1 {
+		new = append(new, "")
+	}
+	return strings.Join(new, "\\")
+}


### PR DESCRIPTION
Since filepath.Clean() is being called in the rancher master it'll always be in Linux, had to write a quick cleaner to use.