### PR TITLE
Get base for copied statefile for snapshot

### DIFF
--- a/pki/deploy.go
+++ b/pki/deploy.go
@@ -64,7 +64,9 @@ func DeployStateOnPlaneHost(ctx context.Context, host *hosts.Host, stateDownload
 	DestinationClusterStateFilePath := path.Join(K8sBaseDir, "/", fmt.Sprintf("%s%s", snapshotName, ClusterStateExt))
 	// This is the location where the 1-on-1 copy from local will be placed in the container, this is later moved to DestinationClusterStateFilePath
 	// Example: /etc/kubernetes/cluster.rkestate
-	SourceClusterStateFilePath := path.Join(K8sBaseDir, stateFilePath)
+	// Example: /etc/kubernetes/rancher-cluster.rkestate
+	baseStateFile := path.Base(stateFilePath)
+	SourceClusterStateFilePath := path.Join(K8sBaseDir, baseStateFile)
 	logrus.Infof("[state] Deploying state file to [%v] on host [%s]", DestinationClusterStateFilePath, host.Address)
 
 	imageCfg := &container.Config{


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/28469

The error was that the full state path was used as check for the file to be copied (```[Waiting for file [/etc/kubernetes/management-state/rke/rke-321165863/cluster.rkestate] to be successfully copied to this container,```), while we only need to check the destionation file name. We extract the filename from the path and use that.

