### PR TITLE
cluster/plan: don't relabel /lib/modules by default

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -602,11 +602,7 @@ func (c *Cluster) BuildKubeProxyProcess(host *hosts.Host, serviceOptions v3.Kube
 			"/run:/run",
 		}
 
-		BindModules := "/lib/modules:/lib/modules:z,ro"
-		if hosts.IsEnterpriseLinuxHost(host) && hosts.IsDockerSELinuxEnabled(host) && !hosts.IsEnterpriseLinuxDocker(host) {
-			// Avoid relabing on Enterprise Linux with Docker SELinux and upstream Docker
-			BindModules = "/lib/modules:/lib/modules:ro"
-		}
+		BindModules := "/lib/modules:/lib/modules:ro"
 		Binds = append(Binds, BindModules)
 	}
 	Binds = append(Binds, host.GetExtraBinds(kubeproxy.BaseService)...)


### PR DESCRIPTION
https://github.com/rancher/rke/issues/2194

As this logic went, it would relabel /lib/modules, except on enterprise
linux and when SELinux is enabled (even just permisive).

Flatcar Container Linux defaults to SELinux on, but permisive, and
`/lib/modules/` is a symlink to the read-only `/usr`.
So `./rke up` would fail on attempting to relabel /usr.

The prior work around is to set `SELINUX=disable` in
/etc/selinux/config.

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>