### PR TITLE
Add CanalControllers to the systemImagesDefaultsMap

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -465,6 +465,7 @@ func (c *Cluster) setClusterImageDefaults() error {
 		&c.SystemImages.CalicoFlexVol:             d(imageDefaults.CalicoFlexVol, privRegURL),
 		&c.SystemImages.CanalNode:                 d(imageDefaults.CanalNode, privRegURL),
 		&c.SystemImages.CanalCNI:                  d(imageDefaults.CanalCNI, privRegURL),
+		&c.SystemImages.CanalControllers:          d(imageDefaults.CanalControllers, privRegURL),
 		&c.SystemImages.CanalFlannel:              d(imageDefaults.CanalFlannel, privRegURL),
 		&c.SystemImages.CanalFlexVol:              d(imageDefaults.CanalFlexVol, privRegURL),
 		&c.SystemImages.WeaveNode:                 d(imageDefaults.WeaveNode, privRegURL),


### PR DESCRIPTION
While the types were added, the actual default logic was missing which led to the network plugin not being able to deploy when using CanalControllers.

https://github.com/rancher/rancher/issues/26717

Signed-off-by: Chris Kim <oats87g@gmail.com>