### PR TITLE
Revert "set ignoreDaemonsets field as nonnullable"

### DIFF
--- a/types/rke_types.go
+++ b/types/rke_types.go
@@ -880,7 +880,7 @@ type NodeDrainInput struct {
 	Force bool `yaml:"force" json:"force,omitempty"`
 	// If there are DaemonSet-managed pods, drain will not proceed without IgnoreDaemonSets set to true
 	// (even when set to true, kubectl won't delete pods - so setting default to true)
-	IgnoreDaemonSets *bool `yaml:"ignore_daemonsets" json:"ignoreDaemonSets,omitempty" norman:"notnullable,default=true"`
+	IgnoreDaemonSets *bool `yaml:"ignore_daemonsets" json:"ignoreDaemonSets,omitempty" norman:"default=true"`
 	// Continue even if there are pods using emptyDir
 	DeleteLocalData bool `yaml:"delete_local_data" json:"deleteLocalData,omitempty"`
 	//Period of time in seconds given to each pod to terminate gracefully.


### PR DESCRIPTION
This reverts commit 998c4fd72db63cc3ba15e5931cee3675e1fad47c.

This changes the type of ignoreDaemonSets from *bool to bool, which was required for terraform. 