### PR TITLE
dind/dind.go: Replace deprecated NewEnvClient()

### DIFF
--- a/dind/dind.go
+++ b/dind/dind.go
@@ -21,7 +21,7 @@ const (
 )
 
 func StartUpDindContainer(ctx context.Context, dindAddress, dindNetwork, dindStorageDriver, dindDNS string) (string, error) {
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return "", err
 	}
@@ -107,7 +107,7 @@ func StartUpDindContainer(ctx context.Context, dindAddress, dindNetwork, dindSto
 }
 
 func RmoveDindContainer(ctx context.Context, dindAddress string) error {
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
replace [deprecated](https://godoc.org/github.com/docker/docker/client#NewEnvClient) ``NewEnvClient`` with [NewClientWithOpts](https://godoc.org/github.com/docker/docker/client#NewClientWithOpts), 
using WithAPIVersionNegotiation as [recommended](https://docs.docker.com/engine/api/sdk/) [here](https://github.com/moby/moby/blob/e180525bb49f2ebde851927b0e24d2b5e5a58b1a/client/client.go#L117).

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>