### PR TITLE
cluster/cluster.go: remove nil comparison in parseIngressConfig()

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -496,9 +496,6 @@ func parseAddonConfig(clusterFile string, rkeConfig *v3.RancherKubernetesEngineC
 }
 
 func parseIngressConfig(clusterFile string, rkeConfig *v3.RancherKubernetesEngineConfig) error {
-	if &rkeConfig.Ingress == nil {
-		return nil
-	}
 	var r map[string]interface{}
 	err := ghodssyaml.Unmarshal([]byte(clusterFile), &r)
 	if err != nil {


### PR DESCRIPTION
The address of a variable always yields a non-nil pointer

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>