### PR TITLE
set default ingress network mode for both rancher and rke

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -514,9 +514,6 @@ func parseIngressConfig(clusterFile string, rkeConfig *v3.RancherKubernetesEngin
 	if err := parseIngressExtraVolumeMounts(ingressMap, rkeConfig); err != nil {
 		return err
 	}
-	if err := parseIngressDefaults(ingressMap, rkeConfig); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -598,21 +595,6 @@ func parseIngressExtraVolumeMounts(ingressMap map[string]interface{}, rkeConfig 
 		return fmt.Errorf("[parseIngressExtraVolumeMounts] error unmarshaling ingress config extraVolumeMounts: %v", err)
 	}
 	rkeConfig.Ingress.ExtraVolumeMounts = volumeMounts
-	return nil
-}
-
-func parseIngressDefaults(ingressMap map[string]interface{}, rkeConfig *v3.RancherKubernetesEngineConfig) error {
-	// Setting up default behaviour so as to not catch out
-	// existing users who use new version of RKE
-	if _, ok := ingressMap["network_mode"]; !ok {
-		rkeConfig.Ingress.NetworkMode = DefaultNetworkMode
-	}
-	if _, ok := ingressMap["http_port"]; !ok {
-		rkeConfig.Ingress.HTTPPort = DefaultHTTPPort
-	}
-	if _, ok := ingressMap["https_port"]; !ok {
-		rkeConfig.Ingress.HTTPSPort = DefaultHTTPSPort
-	}
 	return nil
 }
 

--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -633,6 +633,19 @@ func (c *Cluster) setAddonsDefaults() {
 	if c.Monitoring.Replicas == nil {
 		c.Monitoring.Replicas = &DefaultMonitoringAddonReplicas
 	}
+
+	if c.Ingress.NetworkMode == "" {
+		c.Ingress.NetworkMode = DefaultNetworkMode
+	}
+
+	if c.Ingress.HTTPPort == 0 {
+		c.Ingress.HTTPPort = DefaultHTTPPort
+	}
+
+	if c.Ingress.HTTPSPort == 0 {
+		c.Ingress.HTTPSPort = DefaultHTTPSPort
+	}
+
 }
 
 func setDaemonsetAddonDefaults(updateStrategy *v3.DaemonSetUpdateStrategy) *v3.DaemonSetUpdateStrategy {


### PR DESCRIPTION
Forwardport of https://github.com/rancher/rke/pull/2297

https://github.com/rancher/rancher/issues/29745

Problem:
Setting defaults for ingress in parse logic works only for
rke standalone but not when rancher calls rke using ClusterUp.

Solution:
Setting them during the cluster defaults logic