### PR TITLE
EL - Fix a typo in config.go

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	comments = `# If you intened to deploy Kubernetes in an air-gapped environment,
+	comments = `# If you intended to deploy Kubernetes in an air-gapped environment,
 # please consult the documentation on how to configure custom RKE images.`
 )
 


### PR DESCRIPTION
Fixed a small typo in `config.go` at:
```
const (
	comments = `# If you intened to deploy Kubernetes in an air-gapped environment,
# please consult the documentation on how to configure custom RKE images.`
)
```
to:
```
const (
	comments = `# If you intended to deploy Kubernetes in an air-gapped environment,
# please consult the documentation on how to configure custom RKE images.`
)
```