### PR TITLE
Set default http backend to be optional

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -141,6 +141,7 @@ var (
 	}
 	DefaultClusterProportionalAutoscalerLinearParams = v3.LinearAutoscalerParams{CoresPerReplica: 128, NodesPerReplica: 4, Min: 1, PreventSinglePointFailure: true}
 	DefaultMonitoringAddonReplicas                   = int32(1)
+	DefaultDefaultBackend                            = true
 )
 
 type ExternalFlags struct {
@@ -808,6 +809,9 @@ func (c *Cluster) setAddonsDefaults() {
 		c.Ingress.HTTPSPort = DefaultHTTPSPort
 	}
 
+	if c.Ingress.DefaultBackend == nil {
+		c.Ingress.DefaultBackend = &DefaultDefaultBackend
+	}
 }
 
 func setDaemonsetAddonDefaults(updateStrategy *v3.DaemonSetUpdateStrategy) *v3.DaemonSetUpdateStrategy {

--- a/k8s/deployment.go
+++ b/k8s/deployment.go
@@ -1,0 +1,17 @@
+package k8s
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func DeleteDeploymentIfExists(ctx context.Context, k8sClient *kubernetes.Clientset, name, namespace string) error {
+	err := k8sClient.AppsV1().Deployments(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/k8s/service.go
+++ b/k8s/service.go
@@ -1,0 +1,17 @@
+package k8s
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func DeleteServiceIfExists(ctx context.Context, k8sClient *kubernetes.Clientset, name, namespace string) error {
+	err := k8sClient.CoreV1().Services(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/types/rke_types.go
+++ b/types/rke_types.go
@@ -443,6 +443,8 @@ type IngressConfig struct {
 	NetworkMode string `yaml:"network_mode" json:"networkMode,omitempty"`
 	// Tolerations for Deployments
 	Tolerations []v1.Toleration `yaml:"tolerations" json:"tolerations,omitempty"`
+	// Enable or disable nginx default-http-backend
+	DefaultBackend *bool `yaml:"default_backend" json:"defaultBackend,omitempty" norman:"default=true"`
 }
 
 type ExtraEnv struct {

--- a/types/zz_generated_deepcopy.go
+++ b/types/zz_generated_deepcopy.go
@@ -858,6 +858,11 @@ func (in *IngressConfig) DeepCopyInto(out *IngressConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DefaultBackend != nil {
+		in, out := &in.DefaultBackend, &out.DefaultBackend
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Set default http backend to be optional for ingress nginx. It will be enabled by default.

Relevant Issue: https://github.com/rancher/rancher/issues/25590
Relevant Comment: https://github.com/rancher/rancher/issues/25590#issuecomment-729248564
KDM Data PR: https://github.com/rancher/kontainer-driver-metadata/pull/425