### PR TITLE
Release info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Rancher Kubernetes Engine, an extremely simple, lightning fast Kubernetes installer that works everywhere.
 
+## Latest Release
+
+* v1.2.3 - Read the full release [notes](https://github.com/rancher/rke/releases/tag/v1.2.3).
+
 ## Download
 
 Please check the [releases](https://github.com/rancher/rke/releases/) page.

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func mainErr() error {
 			metadata.RKEVersion = app.Version
 			return nil
 		}
-		logrus.Warnf("This is not an officially supported version (%s) of RKE. Please download the latest official release at https://github.com/rancher/rke/releases/latest", app.Version)
+		logrus.Warnf("This is not an officially supported version (%s) of RKE. Please download the latest official release at https://github.com/rancher/rke/releases", app.Version)
 		return nil
 	}
 	app.Author = "Rancher Labs, Inc."


### PR DESCRIPTION
https://github.com/rancher/rke/issues/2350

Other commit is to remove `latest` from the URL in the warning when using non official releases.