### PR TITLE
[release/v1.2] Remove latest from rke releases URL in warning

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func mainErr() error {
 			metadata.RKEVersion = app.Version
 			return nil
 		}
-		logrus.Warnf("This is not an officially supported version (%s) of RKE. Please download the latest official release at https://github.com/rancher/rke/releases/latest", app.Version)
+		logrus.Warnf("This is not an officially supported version (%s) of RKE. Please download the latest official release at https://github.com/rancher/rke/releases", app.Version)
 		return nil
 	}
 	app.Author = "Rancher Labs, Inc."


### PR DESCRIPTION
Backport of https://github.com/rancher/rke/pull/2351