### PR TITLE
[v1.1] wait for kdm metadata to be initialized

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -704,7 +704,7 @@ func InitClusterObject(ctx context.Context, rkeConfig *v3.RancherKubernetesEngin
 			EncryptionProviderFile: encryptConfig,
 		},
 	}
-	if metadata.K8sVersionToRKESystemImages == nil {
+	if !metadata.MetadataInitialized {
 		if err := metadata.InitMetadata(ctx); err != nil {
 			return nil, err
 		}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -24,16 +24,16 @@ const (
 )
 
 var (
-	RKEVersion                  string
-	DefaultK8sVersion           string
-	K8sVersionToTemplates       map[string]map[string]string
-	K8sVersionToRKESystemImages map[string]v3.RKESystemImages
-	K8sVersionToServiceOptions  map[string]v3.KubernetesServicesOptions
-	K8sVersionToDockerVersions  map[string][]string
-	K8sVersionsCurrent          []string
-	K8sBadVersions              = map[string]bool{}
-
+	RKEVersion                        string
+	DefaultK8sVersion                 string
+	K8sVersionToTemplates             map[string]map[string]string
+	K8sVersionToRKESystemImages       map[string]v3.RKESystemImages
+	K8sVersionToServiceOptions        map[string]v3.KubernetesServicesOptions
+	K8sVersionToDockerVersions        map[string][]string
+	K8sVersionsCurrent                []string
+	K8sBadVersions                    = map[string]bool{}
 	K8sVersionToWindowsServiceOptions map[string]v3.KubernetesServicesOptions
+	MetadataInitialized               bool
 
 	c = http.Client{
 		Timeout: time.Second * 30,
@@ -52,6 +52,7 @@ func InitMetadata(ctx context.Context) error {
 	initAddonTemplates(data)
 	initServiceOptions(data)
 	initDockerOptions(data)
+	MetadataInitialized = true
 	return nil
 }
 


### PR DESCRIPTION
Problem:
We need to wait for initMetadata to complete before reading map values
and that is confirmed only by nil map check. Another initCluster call
could wrongly assume metadata is initialized completely and result into
concurrent read and write map panic.

https://github.com/rancher/rancher/issues/30224

Backport https://github.com/rancher/rke/pull/2354