### PR TITLE
[1.2] Key Rotation - Enhance Logging, Reduce Workers

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -85,6 +85,7 @@ const (
 	FullStateConfigMapName = "full-cluster-state"
 	UpdateStateTimeout     = 30
 	GetStateTimeout        = 30
+	RewriteWorkers         = 5
 	SyncWorkers            = 10
 	NoneAuthorizationMode  = "none"
 	LocalNodeAddress       = "127.0.0.1"


### PR DESCRIPTION
Additional logging has been requested by QA for the rewrite operation.

Reducing the number of workers helps mitigates some request throttling.

Issues: 
- rancher/rancher#28753
- rancher/rancher#30541