### PR TITLE
Exclude Cisco ACI image from mirror

### DIFF
--- a/types/image/mirror.go
+++ b/types/image/mirror.go
@@ -6,7 +6,7 @@ var Mirrors = map[string]string{}
 
 func Mirror(image string) string {
 	orig := image
-	if strings.HasPrefix(image, "weaveworks") {
+	if strings.HasPrefix(image, "weaveworks") || strings.HasPrefix(image, "noiro") {
 		return image
 	}
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/30840

This removes `noiro` (Cisco ACI) prefixed images from the `rancher-images.txt` artifact on release.