### PR TITLE
[v1.1] Added etcd snapshot timeout parameter

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -54,6 +54,7 @@ const (
 	DefaultMonitoringProvider            = "metrics-server"
 	DefaultEtcdBackupConfigIntervalHours = 12
 	DefaultEtcdBackupConfigRetention     = 6
+	DefaultEtcdBackupConfigTimeout       = docker.WaitTimeout
 
 	DefaultDNSProvider = "kube-dns"
 	K8sVersionCoreDNS  = "1.14.0"
@@ -304,6 +305,9 @@ func (c *Cluster) setClusterServicesDefaults() {
 		}
 		if c.Services.Etcd.BackupConfig.Retention == 0 {
 			c.Services.Etcd.BackupConfig.Retention = DefaultEtcdBackupConfigRetention
+		}
+		if c.Services.Etcd.BackupConfig.Timeout == 0 {
+			c.Services.Etcd.BackupConfig.Timeout = DefaultEtcdBackupConfigTimeout
 		}
 	}
 

--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -18,7 +18,12 @@ import (
 func (c *Cluster) SnapshotEtcd(ctx context.Context, snapshotName string) error {
 	backupImage := c.getBackupImage()
 	for _, host := range c.EtcdHosts {
-		if err := services.RunEtcdSnapshotSave(ctx, host, c.PrivateRegistriesMap, backupImage, snapshotName, true, c.Services.Etcd); err != nil {
+		containerTimeout := DefaultEtcdBackupConfigTimeout
+		if c.Services.Etcd.BackupConfig != nil && c.Services.Etcd.BackupConfig.Timeout > 0 {
+			containerTimeout = c.Services.Etcd.BackupConfig.Timeout
+		}
+		newCtx := context.WithValue(ctx, docker.WaitTimeoutContextKey, containerTimeout)
+		if err := services.RunEtcdSnapshotSave(newCtx, host, c.PrivateRegistriesMap, backupImage, snapshotName, true, c.Services.Etcd); err != nil {
 			return err
 		}
 	}
@@ -175,7 +180,12 @@ func (c *Cluster) RestoreEtcdSnapshot(ctx context.Context, snapshotPath string) 
 	initCluster := services.GetEtcdInitialCluster(c.EtcdHosts)
 	backupImage := c.getBackupImage()
 	for _, host := range c.EtcdHosts {
-		if err := services.RestoreEtcdSnapshot(ctx, host, c.PrivateRegistriesMap, c.SystemImages.Etcd, backupImage,
+		containerTimeout := DefaultEtcdBackupConfigTimeout
+		if c.Services.Etcd.BackupConfig != nil && c.Services.Etcd.BackupConfig.Timeout > 0 {
+			containerTimeout = c.Services.Etcd.BackupConfig.Timeout
+		}
+		newCtx := context.WithValue(ctx, docker.WaitTimeoutContextKey, containerTimeout)
+		if err := services.RestoreEtcdSnapshot(newCtx, host, c.PrivateRegistriesMap, c.SystemImages.Etcd, backupImage,
 			snapshotPath, initCluster, c.Services.Etcd); err != nil {
 			return fmt.Errorf("[etcd] Failed to restore etcd snapshot: %v", err)
 		}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -34,6 +34,10 @@ const (
 	StopTimeout = 5
 	// RetryCount is the amount of retries for Docker operations
 	RetryCount = 3
+	// WaitTimeout in seconds
+	WaitTimeout = 300
+	// WaitTimeoutContextKey name
+	WaitTimeoutContextKey = "wait_timeout"
 )
 
 type dockerConfig struct {
@@ -492,8 +496,12 @@ func WaitForContainer(ctx context.Context, dClient *client.Client, hostname stri
 	if dClient == nil {
 		return 1, fmt.Errorf("Failed waiting for container: docker client is nil for container [%s] on host [%s]", containerName, hostname)
 	}
-	// 5 minutes timeout, especially for transferring snapshots
-	for retries := 0; retries < 300; retries++ {
+	// Set containerTimeout value from context or default. Especially for transferring snapshots
+	containerTimeout := WaitTimeout
+	if v, ok := ctx.Value(WaitTimeoutContextKey).(int); ok && v > 0 {
+		containerTimeout = v
+	}
+	for retries := 0; retries < containerTimeout; retries++ {
 		log.Infof(ctx, "Waiting for [%s] container to exit on host [%s]", containerName, hostname)
 		container, err := InspectContainer(ctx, dClient, hostname, containerName)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/rancher/norman v0.0.0-20200520181341-ab75acb55410
-	github.com/rancher/types v0.0.0-20210113191751-adad487bf256
+	github.com/rancher/types v0.0.0-20210121184614-39b83aaa4bed
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -598,8 +598,8 @@ github.com/rancher/norman v0.0.0-20200520181341-ab75acb55410 h1:iPheUCT5yzEWhMsI
 github.com/rancher/norman v0.0.0-20200520181341-ab75acb55410/go.mod h1:j0ffXOmInpTVfy/4M8zLrpgkUOwEe6YFBJ/tzkBss78=
 github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e h1:j6+HqCET/NLPBtew2m5apL7jWw/PStQ7iGwXjgAqdvo=
 github.com/rancher/pkg v0.0.0-20190514055449-b30ab9de040e/go.mod h1:XbYHTPaXuw8ZY9bylhYKQh/nJxDaTKk3YhAxPl4Qy/k=
-github.com/rancher/types v0.0.0-20210113191751-adad487bf256 h1:GePxSoNNd5Bk79GjSDTOS/Cb0V7YuEPjbdxMqCsbhiY=
-github.com/rancher/types v0.0.0-20210113191751-adad487bf256/go.mod h1:HX+ryuo/4a4OtbjPzaCvXWL7nAk5sQN5dP9XQl6iH78=
+github.com/rancher/types v0.0.0-20210121184614-39b83aaa4bed h1:ckLoNNwUCVn6u4JO3PRk/sTamzNG2qp8W5GvoGp1zwI=
+github.com/rancher/types v0.0.0-20210121184614-39b83aaa4bed/go.mod h1:HX+ryuo/4a4OtbjPzaCvXWL7nAk5sQN5dP9XQl6iH78=
 github.com/rancher/wrangler v0.5.4-0.20200326191509-4054411d9736/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=
 github.com/rancher/wrangler v0.5.4-0.20200520040055-b8d49179cfc8 h1:gyboq5L4bx+iWyz4xHHFRqt7wyoou8+akRczPgVlFaQ=
 github.com/rancher/wrangler v0.5.4-0.20200520040055-b8d49179cfc8/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/backup_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/backup_types.go
@@ -23,6 +23,8 @@ type BackupConfig struct {
 	S3BackupConfig *S3BackupConfig `yaml:",omitempty" json:"s3BackupConfig"`
 	// replace special characters in snapshot names
 	SafeTimestamp bool `yaml:"safe_timestamp" json:"safeTimestamp,omitempty"`
+	// Backup execution timeout
+	Timeout int `yaml:"timeout" json:"timeout,omitempty" norman:"default=300"`
 }
 
 type S3BackupConfig struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,7 +212,7 @@ github.com/rancher/norman/types/convert
 github.com/rancher/norman/types/definition
 github.com/rancher/norman/types/slice
 github.com/rancher/norman/types/values
-# github.com/rancher/types v0.0.0-20210113191751-adad487bf256
+# github.com/rancher/types v0.0.0-20210121184614-39b83aaa4bed
 github.com/rancher/types/apis/management.cattle.io/v3
 github.com/rancher/types/apis/project.cattle.io/v3
 github.com/rancher/types/condition


### PR DESCRIPTION
Issue https://github.com/rancher/rancher/issues/30663

Requires https://github.com/rancher/types/pull/1196 : `Timeout` field has been added to `Services.Etcd. BackupConfig`. Once types PR is merged, this PR should be updated to use it.

Required by https://github.com/rancher/rancher/pull/30885

This PR adds the feature to set etcd snapshot timeout instead of the [default](https://github.com/rancher/rke/blob/v1.1.6/docker/docker.go#L495). 

To limit the changes at the rke logic and functions parameters, the `Services.Etcd. BackupConfig.Timeout` field is read at `cluster. SnapshotEtcd` and `cluster.RestoreEtcdSnapshot` functions, using execution context to propagate the argument. `docker.WaitForContainer` function has been modified to set default `WaitTimeout=300` or timeout provided by context value `wait_timeout` if provided