### PR TITLE
Write kubeconfig/state with stricter permission

### DIFF
--- a/cluster/state.go
+++ b/cluster/state.go
@@ -205,7 +205,7 @@ func (s *FullState) WriteStateFile(ctx context.Context, statePath string) error 
 		return fmt.Errorf("Failed to Marshal state object: %v", err)
 	}
 	logrus.Tracef("Writing state file: %s", stateFile)
-	if err := ioutil.WriteFile(statePath, stateFile, 0640); err != nil {
+	if err := ioutil.WriteFile(statePath, stateFile, 0600); err != nil {
 		return fmt.Errorf("Failed to write state file: %v", err)
 	}
 	log.Infof(ctx, "Successfully Deployed state file at [%s]", statePath)

--- a/pki/deploy.go
+++ b/pki/deploy.go
@@ -188,7 +188,7 @@ func DeployAdminConfig(ctx context.Context, kubeConfig, localConfigPath string) 
 	}
 	logrus.Debugf("Deploying admin Kubeconfig locally at [%s]", localConfigPath)
 	logrus.Tracef("Deploying admin Kubeconfig locally: %s", kubeConfig)
-	err := ioutil.WriteFile(localConfigPath, []byte(kubeConfig), 0640)
+	err := ioutil.WriteFile(localConfigPath, []byte(kubeConfig), 0600)
 	if err != nil {
 		return fmt.Errorf("Failed to create local admin kubeconfig file: %v", err)
 	}


### PR DESCRIPTION
https://github.com/rancher/rke/issues/2395

Besides kubeconfig, this also changes rkestate to be written as 0600 instead of 0640