### PR TITLE
Unset proxy env vars when using bastion

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -777,6 +778,12 @@ func (c *Cluster) SetupDialers(ctx context.Context, dailersOptions hosts.Dialers
 		c.K8sWrapTransport, err = hosts.BastionHostWrapTransport(c.BastionHost)
 		if err != nil {
 			return err
+		}
+		if c.BastionHost.IgnoreProxyEnvVars {
+			logrus.Debug("Unset http proxy environment variables")
+			for _, v := range util.ProxyEnvVars {
+				os.Unsetenv(v)
+			}
 		}
 	}
 	return nil

--- a/types/rke_types.go
+++ b/types/rke_types.go
@@ -95,6 +95,8 @@ type BastionHost struct {
 	SSHCert string `yaml:"ssh_cert" json:"sshCert,omitempty"`
 	// SSH Certificate Path
 	SSHCertPath string `yaml:"ssh_cert_path" json:"sshCertPath,omitempty"`
+	// Ignore proxy environment variables
+	IgnoreProxyEnvVars bool `yaml:"ignore_proxy_env_vars" json:"ignoreProxyEnvVars,omitempty"`
 }
 
 type PrivateRegistry struct {

--- a/util/util.go
+++ b/util/util.go
@@ -20,7 +20,7 @@ const (
 	WorkerThreads = 50
 )
 
-var proxyEnvVars = [3]string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+var ProxyEnvVars = [3]string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
 
 func StrToSemVer(version string) (*semver.Version, error) {
 	v, err := semver.NewVersion(strings.TrimPrefix(version, "v"))
@@ -146,7 +146,7 @@ func GetEnvVar(key string) (string, string, bool) {
 
 func PrintProxyEnvVars() {
 	// Print proxy related environment variables
-	for _, proxyEnvVar := range proxyEnvVars {
+	for _, proxyEnvVar := range ProxyEnvVars {
 		var err error
 		// Lookup environment variable
 		if key, value, ok := GetEnvVar(proxyEnvVar); ok {


### PR DESCRIPTION
https://github.com/rancher/rke/issues/2525

Hello ! i use RKE command line for production cluster, all works fine, thanks a lot for this product !

For development and testing purpose, i use terraform RKE provider (based on rke lib) through an SSH bastion and i use terraform Kubernetes provider through a SOCKS proxy with HTTPS_PROXY env var.
But, when rke create the rke-job-deployer ServiceAccount, the k8s client use local http proxy env vars through the SSH tunnel on the bastion, and cannot connect to the kubernetes controlplane.

```
terraform apply
...
module.k8s-full-stack.module.k8s_cluster.rke_cluster.cluster: Still creating... [3m40s elapsed]

Error: 
============= RKE outputs ==============
...
time="2021-04-19T11:15:38+02:00" level=info msg="[controlplane] Successfully started Controller Plane.."
time="2021-04-19T11:15:38+02:00" level=info msg="Using proxy environment variable HTTP_PROXY with value [socks5://localhost:51876]"
time="2021-04-19T11:15:38+02:00" level=info msg="Using proxy environment variable HTTPS_PROXY with value [socks5://localhost:51876]"
time="2021-04-19T11:15:38+02:00" level=info msg="[authz] Creating rke-job-deployer ServiceAccount"

Failed running cluster err:Failed to apply the ServiceAccount needed for job execution: Post "https://grimoire-2.nancy.grid5000.fr:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=30s": proxyconnect tcp: Unable to access the service on localhost:51876. The service might be still starting up. Error: ssh: rejected: connect failed (Connection refused)
```

I propose to unset http proxy env vars when an SSH bastion is used in the RKE configuration.

After recompiling the terraform rke provider with this patched rke lib, all works fine : 

```
terraform apply
...
module.k8s-full-stack.module.k8s_cluster.rke_cluster.cluster: Creating...
...
module.k8s-full-stack.module.k8s_cluster.rke_cluster.cluster: Creation complete after 3m11s [id=55602cee-a3e2-48fe-a164-c0d03f6401a8]
...
module.k8s-full-stack.kubernetes_namespace.metallb: Creating...
module.k8s-full-stack.kubernetes_namespace.rook-ceph: Creating...
module.k8s-full-stack.kubernetes_namespace.metallb: Creation complete after 0s [id=metallb]
module.k8s-full-stack.kubernetes_namespace.rook-ceph: Creation complete after 0s [id=rook-ceph]
```