### PR TITLE
Update cert filename validation to *.pem

### DIFF
--- a/pki/util.go
+++ b/pki/util.go
@@ -592,7 +592,7 @@ func ReadCertsAndKeysFromDir(certDir string) (map[string]CertificatePKI, error) 
 
 	for _, file := range files {
 		logrus.Debugf("[certificates] reading file %s from directory [%s]", file.Name(), certDir)
-		if !strings.HasSuffix(file.Name(), "-key.pem") && !strings.HasSuffix(file.Name(), "-csr.pem") {
+		if strings.HasSuffix(file.Name(), ".pem") && !strings.HasSuffix(file.Name(), "-key.pem") && !strings.HasSuffix(file.Name(), "-csr.pem") {
 			// fetching cert
 			cert, err := getCertFromFile(certDir, file.Name())
 			if err != nil {


### PR DESCRIPTION
Users leveraging custom certs directories face errors when deploying
if the directory contains any files that do not end in .pem. This
change adds additional validation to ensure files are *.pem before
attempting further logic.

Signed-off-by: Alexander Hughes <Alexander.Hughes@pm.me>