### PR TITLE
feat(azure): add tags cloud config field

### DIFF
--- a/types/rke_types.go
+++ b/types/rke_types.go
@@ -836,6 +836,8 @@ type AzureCloudProvider struct {
 	// Excludes master nodes (labeled with `node-role.kubernetes.io/master`) from the backend pool of Azure standard loadbalancer, default(nil) to `true`
 	// If want adding the master nodes to ALB, this should be set to `false` and remove the `node-role.kubernetes.io/master` label from master nodes
 	ExcludeMasterFromStandardLB *bool `json:"excludeMasterFromStandardLB,omitempty" yaml:"excludeMasterFromStandardLB,omitempty"`
+	// Tags to be added to shared resources: `foo=bar,bar=foo`
+	Tags string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 // AWSCloudProvider options


### PR DESCRIPTION
Add `tags` field support to Azure cloud-config definition.
See https://kubernetes-sigs.github.io/cloud-provider-azure/topics/tagging-resources/
