### PR TITLE
Fix issues with custom secrets encryption

### DIFF
--- a/cluster/encryption.go
+++ b/cluster/encryption.go
@@ -510,8 +510,7 @@ func (c *Cluster) readEncryptionCustomConfig() (string, error) {
 		return "", nil
 	}
 
-	return templates.CompileTemplateFromMap(templates.CustomEncryptionProviderFile,
-		struct{ CustomConfig string }{CustomConfig: string(yamlConfig)})
+	return string(yamlConfig), nil
 }
 
 func resolveCustomEncryptionConfig(clusterFile string) (string, *apiserverconfigv1.EncryptionConfiguration, error) {

--- a/cluster/encryption.go
+++ b/cluster/encryption.go
@@ -23,8 +23,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	apiserverconfig "k8s.io/apiserver/pkg/apis/config"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
 	"k8s.io/client-go/kubernetes"
@@ -556,26 +554,12 @@ func parseCustomConfig(customConfig map[string]interface{}) (*apiserverconfigv1.
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling: %v", err)
 	}
-	scheme := runtime.NewScheme()
-	err = apiserverconfig.AddToScheme(scheme)
-	if err != nil {
-		return nil, fmt.Errorf("error adding to scheme: %v", err)
-	}
-	err = apiserverconfigv1.AddToScheme(scheme)
-	if err != nil {
-		return nil, fmt.Errorf("error adding to scheme: %v", err)
-	}
-	codecs := serializer.NewCodecFactory(scheme)
-	decoder := codecs.UniversalDecoder()
-	decodedObj, objType, err := decoder.Decode(data, nil, nil)
 
+	decodedConfig := &apiserverconfigv1.EncryptionConfiguration{}
+	err = json.Unmarshal(data, decodedConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding data: %v", err)
 	}
 
-	decodedConfig, ok := decodedObj.(*apiserverconfigv1.EncryptionConfiguration)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type: %T", objType)
-	}
 	return decodedConfig, nil
 }

--- a/templates/encryption_provider.go
+++ b/templates/encryption_provider.go
@@ -26,9 +26,4 @@ resources:
         secret: {{ $v.Secret -}}
 {{end}}
   - identity: {}`
-
-	CustomEncryptionProviderFile = `apiVersion: apiserver.config.k8s.io/v1
-kind: EncryptionConfiguration
-{{.CustomConfig}}
-`
 )


### PR DESCRIPTION
This allows the `parseCustomConfig` method to return successfully now. I'm not entirely why the previous method failed, since the only difference I can see between the non-versioned and the v1 version of `EncryptionConfiguration` is the json annotations, but.. since the json annotations are now there, the decoder seems a bit unnecessary to use - can just unmarshal the json directly into the object.

Not sure what branch you'd prefer this PR against - if you need it updated, let me know

Resolves https://github.com/rancher/rke/issues/2686