### PR TITLE
allow config kubelet each node

### DIFF
--- a/cluster/hosts.go
+++ b/cluster/hosts.go
@@ -69,11 +69,12 @@ func (c *Cluster) InvertIndexHosts() error {
 	c.ControlPlaneHosts = make([]*hosts.Host, 0)
 	for _, host := range c.Nodes {
 		newHost := hosts.Host{
-			RKEConfigNode: host,
-			ToAddLabels:   map[string]string{},
-			ToDelLabels:   map[string]string{},
-			ToAddTaints:   []string{},
-			ToDelTaints:   []string{},
+			RKEConfigNode:  host,
+			ToAddLabels:    map[string]string{},
+			ToDelLabels:    map[string]string{},
+			ToAddTaints:    []string{},
+			ToDelTaints:    []string{},
+			KubeletService: host.Kubelet,
 			DockerInfo: types.Info{
 				DockerRootDir: "/var/lib/docker",
 			},

--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -538,7 +538,31 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, serviceOptions v3.Kubern
 		Env = append(Env, c.getWindowsEnv(host)...)
 	}
 
-	for arg, value := range host.GetExtraArgs(kubelet.BaseService) {
+	// Overide kubelet config depend on each host
+	mergeService := kubelet.BaseService
+	if host.KubeletService.Image != "" {
+		mergeService.Image = host.KubeletService.Image
+	}
+	if len(host.KubeletService.ExtraArgs) != 0 {
+		mergeService.ExtraArgs = host.KubeletService.ExtraArgs
+	}
+	if len(host.KubeletService.ExtraBinds) != 0 {
+		mergeService.ExtraBinds = host.KubeletService.ExtraBinds
+	}
+	if len(host.KubeletService.ExtraEnv) != 0 {
+		mergeService.ExtraEnv = host.KubeletService.ExtraEnv
+	}
+	if len(host.KubeletService.WindowsExtraArgs) != 0 {
+		mergeService.WindowsExtraArgs = host.KubeletService.WindowsExtraArgs
+	}
+	if len(host.KubeletService.WindowsExtraBinds) != 0 {
+		mergeService.WindowsExtraBinds = host.KubeletService.WindowsExtraBinds
+	}
+	if len(host.KubeletService.WindowsExtraEnv) != 0 {
+		mergeService.WindowsExtraEnv = host.KubeletService.WindowsExtraEnv
+	}
+
+	for arg, value := range host.GetExtraArgs(mergeService) {
 		CommandArgs[arg] = value
 	}
 

--- a/hosts/hosts.go
+++ b/hosts/hosts.go
@@ -38,6 +38,7 @@ type Host struct {
 	UpdateWorker        bool
 	PrefixPath          string
 	BastionHost         v3.BastionHost
+	KubeletService      v3.KubeletService
 }
 
 const (

--- a/types/rke_types.go
+++ b/types/rke_types.go
@@ -230,6 +230,8 @@ type RKEConfigNode struct {
 	Labels map[string]string `yaml:"labels" json:"labels,omitempty"`
 	// Node Taints
 	Taints []RKETaint `yaml:"taints" json:"taints,omitempty"`
+	// Kubelet Service Options
+	Kubelet KubeletService `yaml:"kubelet" json:"kubelet,omitempty"`
 }
 
 type K8sVersionInfo struct {

--- a/types/zz_generated_deepcopy.go
+++ b/types/zz_generated_deepcopy.go
@@ -1464,6 +1464,7 @@ func (in *RKEConfigNode) DeepCopyInto(out *RKEConfigNode) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	in.Kubelet.DeepCopyInto(&out.Kubelet)
 	return
 }
 


### PR DESCRIPTION
This issue mentions in https://github.com/rancher/rke/issues/1285
We should have a way to custom kubelet config on some specific host for flexibility.
Ex: This will config kubelet on host x.x.x.x max-pods to 200.
```
- address: y.y.y.y
...
- address: x.x.x.x
  ...
  kubelet:
    extra_args:
      max-pods: '200'
services:
  kubelet:
    extra_args:
      max-pods: '250'
```