### PR TITLE
add extra args for 1.22

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -381,6 +381,8 @@ func (c *Cluster) BuildKubeControllerProcess(host *hosts.Host, serviceOptions v3
 
 	if matchedRange {
 		Binds = util.RemoveZFromBinds(Binds)
+		CommandArgs["authentication-kubeconfig"] = CommandArgs["kubeconfig"]
+		CommandArgs["authorization-kubeconfig"] = CommandArgs["kubeconfig"]
 	}
 
 	for arg, value := range c.Services.KubeController.ExtraArgs {
@@ -818,6 +820,8 @@ func (c *Cluster) BuildSchedulerProcess(host *hosts.Host, serviceOptions v3.Kube
 
 	if matchedRange {
 		Binds = util.RemoveZFromBinds(Binds)
+		CommandArgs["authentication-kubeconfig"] = CommandArgs["kubeconfig"]
+		CommandArgs["authorization-kubeconfig"] = CommandArgs["kubeconfig"]
 	}
 
 	Binds = append(Binds, c.Services.Scheduler.ExtraBinds...)


### PR DESCRIPTION
controller manager must start with proper authorization and authentication kubeconfig in args starting 1.22. k8s 1.22 has
disabled insecure serving for kube controller manager. https://github.com/kubernetes/kubernetes/pull/96216 

insecure serving for kube scheduler is going to be disabled starting 1.24, so updating the args for it too. 
https://github.com/kubernetes/kubernetes/pull/102857

Related Issue: https://github.com/rancher/rancher/issues/35751