### PR TITLE
Updated version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Rancher Kubernetes Engine, an extremely simple, lightning fast Kubernetes instal
 
 ## Latest Release
 
-* v1.2.13 - Read the full release [notes](https://github.com/rancher/rke/releases/tag/v1.2.13).
+* v1.3.4 - Read the full release [notes](https://github.com/rancher/rke/releases/tag/v1.3.4).
 
 ## Download
 


### PR DESCRIPTION
Discussed it with @deniseschannon and the conclusion is we should reference the latest stable release in default branch's README.MD, so changing it from v1.2.13 (which was already outdated) to v1.3.4.
@superseb , let me know if there is a particular reason we've referenced v1.2.x release since you were the last one updating it.