### PR TITLE
extend pki with support for ed25519/ecdsa certs and certificate chains

### DIFF
--- a/pki/deploy.go
+++ b/pki/deploy.go
@@ -2,7 +2,6 @@ package pki
 
 import (
 	"context"
-	"crypto/rsa"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -297,7 +296,8 @@ func FetchCertificatesFromHost(ctx context.Context, extraHosts []*hosts.Host, ho
 			return nil, err
 		}
 		certificate.Certificate = parsedCert[0]
-		certificate.Key = parsedKey.(*rsa.PrivateKey)
+		certificate.Chain = parsedCert
+		certificate.Key = parsedKey.(cert.PrivateKey)
 		tmpCerts[certName] = certificate
 		logrus.Debugf("[certificates] Recovered certificate: %s", certName)
 	}


### PR DESCRIPTION
Fixes https://github.com/rancher/rke/issues/2597 and https://github.com/rancher/rke/issues/1834.
It would be a start of https://github.com/rancher/rke/issues/1669 as well.

While there is support for reading and writing *ecdsa* certificates,
any private keys that are loaded from files (either from custom certs
or already deployed on the nodes) are being cast to `*rsa.PrivateKey`.
This results in crashes when *ecdsa* certificates are being used.

Similarly, there is built in support for reading certificate chains from
a single certificate file, but then only the leaf certificate is being
processed throughout the whole chain and ultimately written/saved on the
nodes, effectively dropping all cert chain information. This is a major
PITA when using custom certificates with intermediates in the chain.

This commit attempts to fix both this issues:
- a new `PrivateKey` interface is introduced to allow passing around
  both rsa and ecdsa private keys through the pki code
- the `CertificatePKI` type is extended to also hold the certificate
  chain and code is adjusted accordingly to work with that
- internally (rke) generated certificates are still hardcoded to use
  rsa keys, but defaults have been changed to use 4096 bit keys instead
  of the much less secure 2048 bit keys

Additionally support has been added for Ed25519. ECDSA keys use NIST P
curves. Ed25519 offers better security and is faster than NIST P curves.
It is a good idea to have support for them, both in terms of loading from
custom certs as well as generating internally.

All necessary methods to support Ed25519 keys have been added/updated
in this commit. To make it possible to use Ed25519 keys internally
generated by rke appropriate configuration options need to be added to
change the default key type (hardcoded to rsa for backward
compatibility).