### PR TITLE
Prevent  a panic if we enable rotate_encryption_key but disable secrets_encryption_config when creating a cluster

### DIFF
--- a/cmd/encryption.go
+++ b/cmd/encryption.go
@@ -91,7 +91,7 @@ func RotateEncryptionKey(
 		return APIURL, caCrt, clientCert, clientKey, nil, fmt.Errorf("can't rotate encryption keys: Key Rotation is not supported with custom configuration")
 	}
 	if !kubeCluster.IsEncryptionEnabled() {
-		return APIURL, caCrt, clientCert, clientKey, nil, fmt.Errorf("can't rotate encryption keys: Encryption Configuration is disabled")
+		return APIURL, caCrt, clientCert, clientKey, nil, fmt.Errorf("can't rotate encryption keys: Encryption Configuration is disabled. Please disable rotate_encryption_key and run rke up again")
 	}
 
 	kubeCluster.Certificates = rkeFullState.DesiredState.CertificatesBundle

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -104,7 +104,10 @@ func ClusterUp(ctx context.Context, dialersOptions hosts.DialersOptions, flags c
 	}
 	// if we need to rotate the encryption key, do so and then return
 	if kubeCluster.RancherKubernetesEngineConfig.RotateEncryptionKey {
-		return RotateEncryptionKey(ctx, clusterState.CurrentState.RancherKubernetesEngineConfig.DeepCopy(), dialersOptions, flags)
+		// rotate the encryption key only when updating an existing cluster
+		if clusterState.CurrentState.RancherKubernetesEngineConfig != nil {
+			return RotateEncryptionKey(ctx, clusterState.CurrentState.RancherKubernetesEngineConfig.DeepCopy(), dialersOptions, flags)
+		}
 	}
 
 	log.Infof(ctx, "Building Kubernetes cluster")


### PR DESCRIPTION
**Issue**: https://github.com/rancher/rke/issues/2840

**Problem**:
RKE will panic if we enable rotate_encryption_key but disable secrets_encryption_config when creating a cluster. The panic happens because RKE tries to use the rkeConfig, which does not exist. The rkeConfig will be made after the rke up command succeeds.

**Solution**:
Skip the rotateEncryptionKey operation when creating a new cluster. Also, In this case, keys are just made for the first time, so there is no need to rotate them.

**Tests**:
run `rke up` with the following cluster.yml
```
nodes:
  - address:  xxx
    internal_address: xxx
    user: ubuntu
    role: [controlplane,worker,etcd]
    ssh_key_path: xxx
rotate_encryption_key: true
```

Related Rancher Issue: https://github.com/rancher/rancher/issues/36333