### PR TITLE
[release/v1.3] Add pre release notes with k8s versions included

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,9 +45,11 @@ steps:
     checksum:
     - sha256
     files:
-    - "build/bin/rke_*"
+    - "build/bin/rke*"
     prerelease: true
     title: "Pre-release ${DRONE_TAG}"
+    note: ./build/bin/rke-k8sversions.txt
+    overwrite: true
   when:
     instance:
       include:
@@ -66,7 +68,7 @@ steps:
     checksum:
     - sha256
     files:
-    - "build/bin/rke_*"
+    - "build/bin/rke*"
     api_key:
       from_secret: github_token
     title: "Release ${DRONE_TAG}"

--- a/scripts/create-releasenote.sh
+++ b/scripts/create-releasenote.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This script will create a txt file with k8s versions which will be used as (pre) release decription by Drone
+set -e -x
+
+RELEASEFILE="./build/bin/rke-k8sversions.txt"
+
+mkdir -p ./build/bin
+
+echo "Creating ${RELEASEFILE}"
+
+DEFAULT_VERSION=$(./bin/rke --quiet config --list-version)
+if [ $? -ne 0 ]; then
+  echo "Non zero exit code while running 'rke config -l'"
+  exit 1
+fi
+
+DEFAULT_VERSION_FOUND="false"
+echo "# RKE Kubernetes versions" > $RELEASEFILE
+for VERSION in $(./bin/rke --quiet config --all --list-version | sort -V); do
+  if [ "$VERSION" == "$DEFAULT_VERSION" ]; then
+    echo "- \`${VERSION}\` (default)" >> $RELEASEFILE
+    DEFAULT_VERSION_FOUND="true"
+  else
+    echo "- \`${VERSION}\`" >> $RELEASEFILE
+  fi
+done
+
+if [ "$DEFAULT_VERSION_FOUND" == "false" ]; then
+  echo -e "\nNo default version found!" >> $RELEASEFILE
+fi
+
+echo "Done creating ${RELEASEFILE}"
+
+cat $RELEASEFILE

--- a/scripts/package
+++ b/scripts/package
@@ -9,6 +9,8 @@ ARCH=${ARCH:-"amd64"}
 SUFFIX=""
 [ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 
+./scripts/create-releasenote.sh
+
 cd package
 
 TAG=${TAG:-${VERSION}${SUFFIX}}


### PR DESCRIPTION
This adds a release note with includes k8s versions similar to Rancher: https://github.com/rancher/rancher/blob/release/v2.6/.drone.yml#L311