### PR TITLE
[release/v1.3] Check if default k8s version is among all versions

### DIFF
--- a/scripts/integration
+++ b/scripts/integration
@@ -47,8 +47,12 @@ source $(dirname $0)/version
 
 cd $(dirname $0)/..
 
-# Get latest version from rke
+# Get latest major.minor versions from rke
 all_versions=$(./bin/rke --quiet config --all --list-version | sort -V)
+# Get default version from rke
+default_version=$(./bin/rke --quiet config --list-version)
+
+default_version_found="false"
 
 # Get the latest of the major.minor versions.
 for ver in $all_versions; do
@@ -58,11 +62,21 @@ for ver in $all_versions; do
         continue
     fi
 
+    if [ "$ver" == "$default_version" ]; then
+        default_version_found="true"
+    fi
+
     #split value on .
     split=($(echo $ver | tr '.' '\n'))
     major_ver="${split[0]}.${split[1]}"
     versions_to_test["${major_ver}"]="${ver}"
 done
+
+if [ "$default_version_found" == "false" ]; then
+    echo "Default version (${default_version}) not found when listing all latest k8s versions from rke"
+    echo -e "All versions:\n${all_versions}"
+    exit 1
+fi
 
 for ver in "${!versions_to_test[@]}"; do
     version_to_test=${versions_to_test["${ver}"]}


### PR DESCRIPTION
Previous RCs had a default k8s version set that was not in the all supported versions for that RC, for example:

All versions when running `rke config -l -a`:

- v1.19.2-rancher1-1
- v1.20.3-rancher1-2
- v1.21.4-rancher1-1
- v1.22.6-rancher1-2

Default version when running `rke config -l`:

- v1.22.6-rancher1-1

This is caught with this PR and the build exits with code 1.