### PR TITLE
improve the error message for encryption key rotation error.

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -104,8 +104,8 @@ func ClusterUp(ctx context.Context, dialersOptions hosts.DialersOptions, flags c
 	}
 	// if we need to rotate the encryption key, do so and then return
 	if kubeCluster.RancherKubernetesEngineConfig.RotateEncryptionKey {
-		// rotate the encryption key only when updating an existing cluster
-		if clusterState.CurrentState.RancherKubernetesEngineConfig != nil {
+		// rotate the encryption key only when updating an existing cluster which has secret encryption enabled
+		if clusterState.CurrentState.RancherKubernetesEngineConfig != nil && clusterState.CurrentState.RancherKubernetesEngineConfig.Services.KubeAPI.SecretsEncryptionConfig.Enabled {
 			return RotateEncryptionKey(ctx, clusterState.CurrentState.RancherKubernetesEngineConfig.DeepCopy(), dialersOptions, flags)
 		}
 	}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36333

Problem:
RKE has the limitation that we cannot enable the Encryption Key Rotation and Secrets Encryption at the same time when editing an existing cluster. But the error message is not clear.

Solution:
improve the error message for encryption key rotation error. 

