### PR TITLE
Fix panic at updating K8sVersionToRKESystemImages

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -106,7 +106,7 @@ func initDockerOptions(data kdm.Data) {
 }
 
 func initK8sRKESystemImages(data kdm.Data) {
-	K8sVersionToRKESystemImages = map[string]v3.RKESystemImages{}
+	K8sVersionToRKESystemImagesTmp := map[string]v3.RKESystemImages{}
 	rkeData := data
 	// non released versions
 	if RKEVersion == "" {
@@ -132,7 +132,7 @@ func initK8sRKESystemImages(data kdm.Data) {
 			}
 		}
 		// store all for upgrades
-		K8sVersionToRKESystemImages[k8sVersion] = interface{}(systemImages).(v3.RKESystemImages)
+		K8sVersionToRKESystemImagesTmp[k8sVersion] = interface{}(systemImages).(v3.RKESystemImages)
 
 		majorVersion := getTagMajorVersion(k8sVersion)
 		maxVersionInfo, ok := rkeData.K8sVersionInfo[majorVersion]
@@ -150,6 +150,8 @@ func initK8sRKESystemImages(data kdm.Data) {
 	for _, k8sVersion := range maxVersionForMajorK8sVersion {
 		K8sVersionsCurrent = append(K8sVersionsCurrent, k8sVersion)
 	}
+
+	K8sVersionToRKESystemImages = K8sVersionToRKESystemImagesTmp
 }
 
 func getTagMajorVersion(tag string) string {


### PR DESCRIPTION
Using Rancher version 2.4.3.
Large installation with 100+ clusters and 10+ cattle-servers pods in HA mode.

There's panic at concurrent read-write access to K8sVersionToRKESystemImages map:

```
Mar 9, 2022 @ 11:48:46.568 fatal error: concurrent map read and map write
Mar 9, 2022 @ 11:48:46.574 github.com/rancher/rancher/vendor/github.com/rancher/rke/cluster.(*Cluster).setClusterImageDefaults(0xc075c1e000, 0x20, 0xc070913580)

	/go/src/github.com/rancher/rancher/vendor/github.com/rancher/rke/cluster/defaults.go:433 +0x86 fp=0xc13711c188 sp=0xc13711b968 pc=0x22f5426
```

Seems map reading is happening at the same time as updating map.
The only place where it is modified is in rke/metadata/metadata.go.
This PR avoids map update by substituting map.