### PR TITLE
Add logic to fix coreDNS add-on config issue while cluster upgrade

### DIFF
--- a/cluster/addons.go
+++ b/cluster/addons.go
@@ -186,6 +186,18 @@ func (c *Cluster) deployK8sAddOns(ctx context.Context, data map[string]interface
 func (c *Cluster) deployUserAddOns(ctx context.Context) error {
 	log.Infof(ctx, "[addons] Setting up user addons")
 	if c.Addons != "" {
+		addonJobExists, err := addons.AddonJobExists(UserAddonJobName, c.LocalKubeConfigPath, c.K8sWrapTransport)
+		if err != nil {
+			return nil
+		}
+		if addonJobExists {
+			log.Infof(ctx, "[addons] Removing old user addons")
+			if err := c.doAddonDelete(ctx, UserAddonResourceName, false); err != nil {
+				return err
+			}
+
+			log.Infof(ctx, "[addons] Old user addons removed successfully")
+		}
 		if err := c.doAddonDeploy(ctx, c.Addons, UserAddonResourceName, false); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes: https://github.com/rancher/rancher/issues/36985

For every user addon, rke runs an `rke-user-addon-deploy-job` job, which applies the user add-on configs to the cluster. Although when the cluster version gets updated, the user addon needs to be re-applied.

Currently if the user addons are previously applied, they get ignored subsequently, even if the k8s version is being upgraded. Hence, this PR changes that behavior to force-apply the user addons for each `rke up` command run. This will make sure that even if the k8s version of the cluster is upgraded, the user addon changes do not get lost.