### PR TITLE
Add fields `ExtraArgsArray` and `WindowsExtraArgsArray`

### DIFF
--- a/hosts/hosts.go
+++ b/hosts/hosts.go
@@ -420,6 +420,13 @@ func (h *Host) GetExtraArgs(service v3.BaseService) map[string]string {
 	}
 }
 
+func (h *Host) GetExtraArgsArray(service v3.BaseService) map[string][]string {
+	if h.OS() == "windows" && len(service.WindowsExtraArgsArray) > 0 {
+		return service.WindowsExtraArgsArray
+	}
+	return service.ExtraArgsArray
+}
+
 func DoRunLogCleaner(ctx context.Context, host *Host, alpineImage string, prsMap map[string]v3.PrivateRegistry) error {
 	logrus.Debugf("[cleanup] Starting log link cleanup on host [%s]", host.Address)
 	imageCfg := &container.Config{

--- a/types/rke_types.go
+++ b/types/rke_types.go
@@ -364,6 +364,8 @@ type BaseService struct {
 	Image string `yaml:"image" json:"image,omitempty"`
 	// Extra arguments that are added to the services
 	ExtraArgs map[string]string `yaml:"extra_args" json:"extraArgs,omitempty"`
+	// Extra arguments that can be specified multiple times which are added to the services
+	ExtraArgsArray map[string][]string `yaml:"extra_args_array" json:"extraArgsArray,omitempty"`
 	// Extra binds added to the nodes
 	ExtraBinds []string `yaml:"extra_binds" json:"extraBinds,omitempty"`
 	// this is to provide extra env variable to the docker container running kubernetes service
@@ -372,6 +374,8 @@ type BaseService struct {
 	// Windows nodes only of the same as the above
 	// Extra arguments that are added to the services
 	WindowsExtraArgs map[string]string `yaml:"win_extra_args" json:"winExtraArgs,omitempty"`
+	// Extra arguments that can be specified multiple times which are added to the services
+	WindowsExtraArgsArray map[string][]string `yaml:"win_extra_args_array" json:"winExtraArgsArray,omitempty"`
 	// Extra binds added to the nodes
 	WindowsExtraBinds []string `yaml:"win_extra_binds" json:"winExtraBinds,omitempty"`
 	// this is to provide extra env variable to the docker container running kubernetes service

--- a/types/zz_generated_deepcopy.go
+++ b/types/zz_generated_deepcopy.go
@@ -249,6 +249,21 @@ func (in *BaseService) DeepCopyInto(out *BaseService) {
 			(*out)[key] = val
 		}
 	}
+	if in.ExtraArgsArray != nil {
+		in, out := &in.ExtraArgsArray, &out.ExtraArgsArray
+		*out = make(map[string][]string, len(*in))
+		for key, val := range *in {
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
+		}
+	}
 	if in.ExtraBinds != nil {
 		in, out := &in.ExtraBinds, &out.ExtraBinds
 		*out = make([]string, len(*in))
@@ -264,6 +279,21 @@ func (in *BaseService) DeepCopyInto(out *BaseService) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.WindowsExtraArgsArray != nil {
+		in, out := &in.WindowsExtraArgsArray, &out.WindowsExtraArgsArray
+		*out = make(map[string][]string, len(*in))
+		for key, val := range *in {
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.WindowsExtraBinds != nil {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/25500
 
# Problem
When setting up [service account token volume projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) within the cluster.yaml, users were not able to specify a flag multiple times with different values within the `ExtraArgs` section of the `kubeapi` service. This prevents users from specifying multiple `service-account-key-file`’s, multiple `service-account-issuer`’s, or multiple `api-audiences`. This issue may also exist for the other services, and is not specific to service account projection (although that is the requested usecase)

# Solution
In an effort to preserve backwards compatibility, two new fields have been added to the `BaseService`: `ExtraArgsArray`/`extra_args_array` & `WindowsExtraArgsArray`/`win_extra_args_array`. These fields have a type of `map[string][]string`, as opposed to the type of `map[string]string` which is used for the existing `extraArgs` field. These new fields allow users to specify arguments multiple times with different values. These new fields can be used within any of the services within the cluster.yaml. _If anyone has any better names for these two fields please let me know, I'm happy to change them._ 

# Testing
I was able to utilize the new field within the `kubeapi` service when creating or modifying a cluster. I was able to observe updates / failures when specifying valid or invalid values for the arguments. Here are the test cases I have performed:

Test case 1) 
 + Create a new DO cluster (1 node, all roles)
 + Once available, SSH into the node
   + run the following commands 
     + `cp /etc/kubernetes/ssl/kube-apiserver-key.pem /etc/kubernetes/ssl/kube-apiserver-key2.pem`
     + `cp /etc/kubernetes/ssl/kube-apiserver-key.pem /etc/kubernetes/ssl/kube-apiserver-key3.pem`
 + modify the cluster.yaml and replace the `kubeapi` section with the following 
```
kube-api:
      always_pull_images: false
      extra_args_array:
        service-account-key-file:
          - /etc/kubernetes/ssl/kube-apiserver-key.pem
          - /etc/kubernetes/ssl/kube-apiserver-key2.pem
          - /etc/kubernetes/ssl/kube-apiserver-key3.pem
      pod_security_policy: false
      secrets_encryption_config:
        enabled: false
      service_node_port_range: 30000-32767
```
 + apply changes and observe cluster go into `active` state

Test case 2) 
 + create new downstream cluster in DO (1 node, all roles)
 + modify the cluster yaml BEFORE creating the cluster
 + Replace the `kube-api` field with the following value 
```kube-api:
      always_pull_images: false
      extra_args_array:
        service-account-key-file:
          - /etc/kubernetes/ssl/kube-apiserver-key.pem
          - /etc/kubernetes/ssl/blah.pem
      pod_security_policy: false
      secrets_encryption_config:
        enabled: false
      service_node_port_range: 30000-32767
```
+ Save the cluster 
+ Observe cluster errors out with the following error (expected) ```
[controlPlane] Failed to upgrade Control Plane: [[Failed to verify healthcheck: Failed to check https://localhost:6443/healthz for service [kube-apiserver] on host [104.131.53.240]: Get "https://localhost:6443/healthz": dial tcp [::1]:6443: connect: connection refused, log: Error: open /etc/kubernetes/ssl/blah.pem: no such file or directory]]```

If there are other test cases I should attempt before merging this PR let me know!
