### PR TITLE
[release/v1.3] Add workflow to create PR in Rancher on tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -83,6 +83,24 @@ steps:
       - "refs/tags/*rc*"
       - "refs/tags/*alpha*"
 
+- name: dispatch
+  image: curlimages/curl:7.81.0
+  user: root
+  environment:
+    PAT_USERNAME:
+      from_secret: pat_username
+    PAT_TOKEN:
+      from_secret: github_token
+  commands:
+  - apk -U --no-cache add bash
+  - scripts/dispatch
+  when:
+    instance:
+      include:
+      - drone-publish.rancher.io
+    event:
+    - tag
+
 volumes:
 - name: socket
   host:

--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+set -x
+
+REPO="https://api.github.com/repos/rancher/rancher/actions/workflows/go-get.yml/dispatches"
+
+case $DRONE_TAG in
+  "v1.3"*)
+    ACTION_TARGET_BRANCH="release/v2.6"
+    ;;
+  *)
+    echo "Not a valid tag, not dispatching event"
+    exit 0
+esac
+
+echo "DRONE_TAG: $DRONE_TAG"
+echo "DRONE_COMMIT_AUTHOR: $DRONE_COMMIT_AUTHOR"
+
+echo "Dispatching to branch ${ACTION_TARGET_BRANCH}"
+
+# send dispatch event to workflow
+curl -XPOST -u "${PAT_USERNAME}:${PAT_TOKEN}" \
+        -H "Accept: application/vnd.github.v3+json"  \
+        -H "Content-Type: application/json" $REPO \
+        --data '{"ref": "'"$ACTION_TARGET_BRANCH"'","inputs":{"goget_module":"github.com/rancher/rke","goget_version":"'"$DRONE_TAG"'","source_author":"'"$DRONE_COMMIT_AUTHOR"'"}}'


### PR DESCRIPTION
This enables to dispatch the workflow in rancher/rancher to run `go get` on the newly created tag in RKE and create a PR with the changes.