### PR TITLE
Use cluster-level SSHCertPath for Nodes if set

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -200,6 +200,9 @@ func (c *Cluster) setClusterDefaults(ctx context.Context, flags ExternalFlags) e
 		if len(host.SSHKeyPath) == 0 {
 			c.Nodes[i].SSHKeyPath = c.SSHKeyPath
 		}
+		if len(host.SSHCertPath) == 0 {
+			c.Nodes[i].SSHCertPath = c.SSHCertPath
+		}
 		if len(host.Port) == 0 {
 			c.Nodes[i].Port = DefaultSSHPort
 		}


### PR DESCRIPTION
Duplicates the logic used for SSHKeyPath values for hosts, to SSHCertPath, set by the cluster.
Should fix cluster-level ssh cert usage. I was unable to find a place where the cluster-level SSHCertPath was being read and it seemed to be failing for my use case (vault ssh certificate signing).

At least *related* to #2863 .

Thanks!