### PR TITLE
always set kubelet node-ip to internal address

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -473,7 +473,7 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, serviceOptions v3.Kubern
 	if host.IsControl && !host.IsWorker {
 		CommandArgs["register-with-taints"] = unschedulableControlTaint
 	}
-	if host.Address != host.InternalAddress {
+	if host.InternalAddress != "" {
 		CommandArgs["node-ip"] = host.InternalAddress
 	}
 	if len(c.CloudProvider.Name) > 0 {


### PR DESCRIPTION
Currently, there is no way to set the kubelet `node-ip` if `host.Address` is the same as `host.InternalAddress`.

Shouldn't it be possible to always set the kubelet `node-ip` to the internal address, if that one is set?

In my case, the node has two interfaces, one for the default route and one for the internal cluster address. However, the internal cluster address is the one used for rke provisioning as well. Therefore, the host address and the internal address are equal.
By default, the kubelet will select the address from the default route interface and there seems to be no way to override this one.