### PR TITLE
Fix ingress' HTTPS port validation

### DIFF
--- a/cluster/validation.go
+++ b/cluster/validation.go
@@ -377,7 +377,7 @@ func validateIngressOptions(c *Cluster) error {
 	}
 
 	if c.Ingress.NetworkMode == "hostPort" {
-		if !(c.Ingress.HTTPPort >= 0 && c.Ingress.HTTPPort <= 65535) {
+		if !(c.Ingress.HTTPSPort >= 0 && c.Ingress.HTTPSPort <= 65535) {
 			return fmt.Errorf("https port is invalid. Needs to be within 0 to 65535")
 		}
 		if !(c.Ingress.HTTPPort >= 0 && c.Ingress.HTTPPort <= 65535) {


### PR DESCRIPTION
This commit fixes a typo that causes that HTTPS ingress port is not validated correctly.