### PR TITLE
bind rke kubelet docker config path to default docker config path

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -512,7 +512,8 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, serviceOptions v3.Kubern
 		// cri-dockerd must be enabled if the cluster version is 1.24 and higher
 		if parsedRangeAtLeast124(parsedVersion) {
 			CommandArgs["container-runtime-endpoint"] = "unix:///var/run/cri-dockerd.sock"
-			Binds = []string{fmt.Sprintf("%s:/var/lib/cri-dockerd:z", path.Join(host.PrefixPath, "/var/lib/cri-dockerd"))}
+			Binds = []string{fmt.Sprintf("%s:/var/lib/cri-dockerd:z", path.Join(host.PrefixPath, "/var/lib/cri-dockerd")),
+				fmt.Sprintf("%s:%s", path.Join(host.PrefixPath, KubeletDockerConfigPath), "/.docker/config.json")}
 		}
 	}
 


### PR DESCRIPTION
Add bind `/var/lib/kubelet/config.json:/.docker/config.json`

## Issue: 
Pod creation failing with following error when using private registry: 
`
E0801 21:49:55.450436    6271 kuberuntime_manager.go:815] "CreatePodSandbox for pod failed" err="rpc error: code = Unknown desc = failed pulling image \"ec2-3-144-97-102.us-east-2.compute.amazonaws.com/rancher/mirrored-pause:3.6\": Error response from daemon: Get https://ec2-3-144-97-102.us-east-2.compute.amazonaws.com/v2/rancher/mirrored-pause/manifests/3.6: no basic auth credentials" pod="kube-system/rke-network-plugin-deploy-job-92w6t"
`
https://github.com/rancher/rancher/issues/38473

## Problem
RKE stores docker config at `/var/lib/kubelet/config.json` (https://github.com/rancher/rke-tools/blob/master/entrypoint.sh#L75) , but the external cri-dockerd relies on k8s credential plugin which reads only from default docker config locations (https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/config.go#L136). No auth information is currently found so cri-dockerd defaults to pulling sandbox image (pause image) without credentials and provisioning breaks when using private registry (https://github.com/Mirantis/cri-dockerd/blob/master/core/sandbox_helpers.go#L422) 

## Solution
The solution is to mount rke's default config.json to /.docker/config.json path where cri-dockerd expects it. 
 
## Testing
- Tested using `kinarashah/rke-tools:test` which is updated to pull hardcoded private image `kinarashah/pause:3.6` https://github.com/kinarashah/rke-tools/blob/pro/entrypoint.sh#L85 