### PR TITLE
Ensure NodeLocal.IPaddress is passed when creating CommandArgs

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -630,13 +630,13 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, serviceOptions v3.Kubern
 		CommandArrayArgs[arg] = value
 	}
 
-	Command = appendArgs(Command, CommandArgs)
-	Command = appendArrayArgs(Command, CommandArrayArgs)
-
 	// If nodelocal DNS is configured, set cluster-dns to local IP
 	if c.DNS.Nodelocal != nil && c.DNS.Nodelocal.IPAddress != "" {
 		CommandArgs["cluster-dns"] = c.DNS.Nodelocal.IPAddress
 	}
+
+	Command = appendArgs(Command, CommandArgs)
+	Command = appendArrayArgs(Command, CommandArrayArgs)
 
 	healthCheck := v3.HealthCheck{
 		URL: services.GetHealthCheckURL(false, services.KubeletPort),


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/38564

The `cluster-dns` argument was left behind after creating the command arguments for the `kubelet`. This PR changes the ordering so that the argument is persisted after calling `appendArgs`. 