### PR TITLE
Add `tags` field to the Azure cloud provider

### DIFF
--- a/types/rke_types.go
+++ b/types/rke_types.go
@@ -859,6 +859,8 @@ type AzureCloudProvider struct {
 	// Excludes master nodes (labeled with `node-role.kubernetes.io/master`) from the backend pool of Azure standard loadbalancer, default(nil) to `true`
 	// If want adding the master nodes to ALB, this should be set to `false` and remove the `node-role.kubernetes.io/master` label from master nodes
 	ExcludeMasterFromStandardLB *bool `json:"excludeMasterFromStandardLB,omitempty" yaml:"excludeMasterFromStandardLB,omitempty"`
+	// Tags to be added to shared resources: `foo=bar,bar=foo`
+	Tags string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 // AWSCloudProvider options


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/26955
Backport for:  https://github.com/rancher/rke/issues/2611

This is a back-port PR which introduces the `tags` field to the Azure Cloud Provider for RKE 1.3.x