### PR TITLE
check for empty update strategy while setting default values for dns addon deployment

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -306,7 +306,7 @@ func (c *Cluster) setNodeUpgradeStrategy() {
 }
 
 // setCRIDockerd set enable_cri_dockerd = true when the following two conditions are met:
-//the cluster's version is at least 1.24 and the option enable_cri_dockerd is not configured
+// the cluster's version is at least 1.24 and the option enable_cri_dockerd is not configured
 func (c *Cluster) setCRIDockerd() error {
 	parsedVersion, err := getClusterVersion(c.Version)
 	if err != nil {
@@ -952,7 +952,8 @@ func setDNSDeploymentAddonDefaults(updateStrategy *v3.DeploymentStrategy, dnsPro
 		coreDNSMaxUnavailable, coreDNSMaxSurge = intstr.FromInt(1), intstr.FromInt(0)
 		kubeDNSMaxSurge, kubeDNSMaxUnavailable = intstr.FromString("10%"), intstr.FromInt(0)
 	)
-	if updateStrategy != nil && updateStrategy.Strategy != appsv1.RollingUpdateDeploymentStrategyType {
+	if updateStrategy != nil && updateStrategy.Strategy != appsv1.RollingUpdateDeploymentStrategyType &&
+		updateStrategy.Strategy != "" {
 		return updateStrategy
 	}
 	switch dnsProvider {


### PR DESCRIPTION
required the PR: https://github.com/rancher/rke/pull/3086 to be merged first since CI is likely to fail because of kdm data.json being out of sync.

fix for issue: https://github.com/rancher/rancher/issues/37461
