### PR TITLE
[release/v1.4] Improve getting releases/tags when updating README

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -12,14 +12,17 @@ jobs:
     - uses: actions/checkout@v2
     - name: Update README file
       run: |
-       tmpfile=$(mktemp)
-       wget https://api.github.com/repos/rancher/rke/tags?per_page=1000 -O tags.yaml
+       tagstmpfile=$(mktemp)
+       readmetmpfile=$(mktemp)
+       gh api graphql -F owner='rancher' -F name='rke' -f query='query($name: String!, $owner: String!) {repository(owner: $owner, name: $name) {releases(first: 100) {nodes { tagName }}}}' |jq -r .data.repository.releases[] > $tagstmpfile
        for rke_major_minor in 1.4 1.3 1.2; do
-         latest=$(jq -r 'first(.[] | select(.name | startswith("v'"${rke_major_minor}"'")) | select(.name | contains("rc") | not) | .name)' tags.yaml)
-         echo "* v${rke_major_minor}" >> $tmpfile
-         echo "  * ${latest} - Read the full release [notes](https://github.com/rancher/rke/releases/tag/${latest})." >> $tmpfile
+         latest=$(jq -r 'first(.[] | select(.tagName | startswith("v'"${rke_major_minor}"'")) | select(.tagName | contains("rc") | not) | .tagName)' $tagstmpfile)
+         echo "* v${rke_major_minor}" >> $readmetmpfile
+         echo "  * ${latest} - Read the full release [notes](https://github.com/rancher/rke/releases/tag/${latest})." >> $readmetmpfile
        done
-       sed -e '/## Latest Release/r '"$tmpfile"'' -e 's/CURRENTYEAR/'"$(date +%Y)"'/g' README-template.md > README.md
+       sed -e '/## Latest Release/r '"$readmetmpfile"'' -e 's/CURRENTYEAR/'"$(date +%Y)"'/g' README-template.md > README.md
+      env:
+        GH_TOKEN: ${{ github.token }}
     - name: Check for repository changes
       run: |
         if git diff --name-only --exit-code; then


### PR DESCRIPTION
As seen in https://github.com/rancher/rke/pull/3111, the `wget` is not sufficient to get enough tags to list the latest for v1.2.x. This changes the logic to use the included GitHub CLI to retrieve releases and filter on that output.

Tested in https://github.com/sebtestorg2/actions-test/actions/runs/3572161876, resulting PR https://github.com/sebtestorg2/actions-test/pull/134/files