### PR TITLE
Backport: added variables for ACI-CNI 5.2.3.4

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -112,6 +112,8 @@ const (
 	DefaultAciNodePodIfEnable                   = "false"
 	DefaultAciSriovEnable                       = "false"
 	DefaultAciMultusDisable                     = "true"
+	DefaultAciNoWaitForServiceEpReadiness       = "false"
+	DefaultAciAddExternalSubnetsToRdconfig      = "false"
 
 	KubeAPIArgAdmissionControlConfigFile             = "admission-control-config-file"
 	DefaultKubeAPIArgAdmissionControlConfigFileValue = "/etc/kubernetes/admission.yaml"
@@ -668,6 +670,8 @@ func (c *Cluster) setClusterNetworkDefaults() {
 			AciNodePodIfEnable:                   DefaultAciNodePodIfEnable,
 			AciSriovEnable:                       DefaultAciSriovEnable,
 			AciMultusDisable:                     DefaultAciMultusDisable,
+			AciNoWaitForServiceEpReadiness:       DefaultAciNoWaitForServiceEpReadiness,
+			AciAddExternalSubnetsToRdconfig:      DefaultAciAddExternalSubnetsToRdconfig,
 		}
 	}
 	if c.Network.CalicoNetworkProvider != nil {
@@ -724,6 +728,8 @@ func (c *Cluster) setClusterNetworkDefaults() {
 		setDefaultIfEmpty(&c.Network.AciNetworkProvider.DurationWaitForNetwork, DefaultAciDurationWaitForNetwork)
 		setDefaultIfEmpty(&c.Network.AciNetworkProvider.DisableWaitForNetwork, DefaultAciDisableWaitForNetwork)
 		setDefaultIfEmpty(&c.Network.AciNetworkProvider.UseClusterRole, DefaultAciUseClusterRole)
+		setDefaultIfEmpty(&c.Network.AciNetworkProvider.NoWaitForServiceEpReadiness, DefaultAciNoWaitForServiceEpReadiness)
+		setDefaultIfEmpty(&c.Network.AciNetworkProvider.AddExternalSubnetsToRdconfig, DefaultAciAddExternalSubnetsToRdconfig)
 		networkPluginConfigDefaultsMap[AciOVSMemoryLimit] = c.Network.AciNetworkProvider.OVSMemoryLimit
 		networkPluginConfigDefaultsMap[AciImagePullPolicy] = c.Network.AciNetworkProvider.ImagePullPolicy
 		networkPluginConfigDefaultsMap[AciPBRTrackingNonSnat] = c.Network.AciNetworkProvider.PBRTrackingNonSnat
@@ -763,6 +769,8 @@ func (c *Cluster) setClusterNetworkDefaults() {
 		networkPluginConfigDefaultsMap[AciNodePodIfEnable] = c.Network.AciNetworkProvider.NodePodIfEnable
 		networkPluginConfigDefaultsMap[AciSriovEnable] = c.Network.AciNetworkProvider.SriovEnable
 		networkPluginConfigDefaultsMap[AciMultusDisable] = c.Network.AciNetworkProvider.MultusDisable
+		networkPluginConfigDefaultsMap[AciNoWaitForServiceEpReadiness] = c.Network.AciNetworkProvider.NoWaitForServiceEpReadiness
+		networkPluginConfigDefaultsMap[AciAddExternalSubnetsToRdconfig] = c.Network.AciNetworkProvider.AddExternalSubnetsToRdconfig
 		networkPluginConfigDefaultsMap[AciSystemIdentifier] = c.Network.AciNetworkProvider.SystemIdentifier
 		networkPluginConfigDefaultsMap[AciToken] = c.Network.AciNetworkProvider.Token
 		networkPluginConfigDefaultsMap[AciApicUserName] = c.Network.AciNetworkProvider.ApicUserName

--- a/cluster/network.go
+++ b/cluster/network.go
@@ -147,6 +147,8 @@ const (
 	AciNodePodIfEnable                   = "aci_node_pod_if_enable"
 	AciSriovEnable                       = "aci_sriov_enable"
 	AciMultusDisable                     = "aci_multus_disable"
+	AciNoWaitForServiceEpReadiness       = "aci_no_wait_for_service_ep_readiness"
+	AciAddExternalSubnetsToRdconfig      = "aci_add_external_subnets_to_rdconfig"
 	// List of map keys to be used with network templates
 
 	// EtcdEndpoints is the server address for Etcd, used by calico
@@ -283,6 +285,8 @@ const (
 	NodePodIfEnable                        = "NodePodIfEnable"
 	SriovEnable                            = "SriovEnable"
 	MultusDisable                          = "MultusDisable"
+	NoWaitForServiceEpReadiness            = "NoWaitForServiceEpReadiness"
+	AddExternalSubnetsToRdconfig           = "AddExternalSubnetsToRdconfig"
 	OVSMemoryLimit                         = "OVSMemoryLimit"
 	NodeSubnet                             = "NodeSubnet"
 	NodeSelector                           = "NodeSelector"
@@ -579,6 +583,8 @@ func (c *Cluster) doAciDeploy(ctx context.Context, data map[string]interface{}) 
 		NodePodIfEnable:                   c.Network.Options[AciNodePodIfEnable],
 		SriovEnable:                       c.Network.Options[AciSriovEnable],
 		MultusDisable:                     c.Network.Options[AciMultusDisable],
+		NoWaitForServiceEpReadiness:       c.Network.Options[AciNoWaitForServiceEpReadiness],
+		AddExternalSubnetsToRdconfig:      c.Network.Options[AciAddExternalSubnetsToRdconfig],
 		AciCniDeployContainer:             c.SystemImages.AciCniDeployContainer,
 		AciHostContainer:                  c.SystemImages.AciHostContainer,
 		AciOpflexContainer:                c.SystemImages.AciOpflexContainer,

--- a/types/rke_types.go
+++ b/types/rke_types.go
@@ -661,6 +661,8 @@ type AciNetworkProvider struct {
 	SriovEnable                       string   `yaml:"sriov_enable,omitempty" json:"sriovEnable,omitempty"`
 	MultusDisable                     string   `yaml:"multus_disable,omitempty" json:"multusDisable,omitempty"`
 	UseClusterRole                    string   `yaml:"use_cluster_role,omitempty" json:"useClusterRole,omitempty"`
+	NoWaitForServiceEpReadiness       string   `yaml:"no_wait_for_service_ep_readiness,omitempty" json:"noWaitForServiceEpReadiness,omitempty"`
+	AddExternalSubnetsToRdconfig      string   `yaml:"add_external_subnets_to_rdconfig,omitempty" json:"addExternalSubnetsToRdconfig,omitempty"`
 }
 
 type KubernetesServicesOptions struct {


### PR DESCRIPTION
Back port of https://github.com/rancher/rke/pull/3039