### PR TITLE
[release/v1.3.20] Add missing calico logs volumeMount

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -571,6 +571,7 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, serviceOptions v3.Kubern
 			"/dev:/host/dev:rprivate",
 			"/var/log/containers:/var/log/containers:z",
 			"/var/log/pods:/var/log/pods:z",
+			"/var/log/calico/cni:/var/log/calico/cni:z",
 			"/usr:/host/usr:ro",
 			"/etc:/host/etc:ro",
 		}...)


### PR DESCRIPTION
There was a missing volumeMount which was causing the calico/canal logs getting written to the container overlay filesystem causing the container to fill up. Adding the missing bind resolves this issue. 

Linked issue: https://github.com/rancher/rancher/issues/40540
SURE: 5814