### PR TITLE
[release/v1.4] Move to BCI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 steps:
 - name: ci
   pull: default
-  image: rancher/dapper:1.11.2
+  image: rancher/dapper:v0.6.0
   commands:
   - dapper ci
   - ls -lR build/bin
@@ -23,18 +23,6 @@ steps:
     event:
     - pull_request
     - tag
-
-- name: stage-binaries
-  pull: default
-  image: rancher/dapper:1.11.2
-  commands:
-  - "cp -r ./bin/* ./package/"
-  when:
-    event:
-    - tag
-    ref:
-      include:
-      - "refs/tags/*"
 
 - name: github_binary_prerelease
   pull: default
@@ -117,7 +105,7 @@ platform:
 steps:
 - name: build
   pull: default
-  image: rancher/dapper:1.11.2
+  image: rancher/dapper:v0.6.0
   commands:
   - dapper build
   privileged: true
@@ -131,7 +119,7 @@ steps:
 
 - name: integration-flannel
   pull: default
-  image: rancher/dapper:1.11.2
+  image: rancher/dapper:v0.6.0
   commands:
   - dapper integration flannel
   privileged: true
@@ -145,7 +133,7 @@ steps:
 
 - name: integration-calico
   pull: default
-  image: rancher/dapper:1.11.2
+  image: rancher/dapper:v0.6.0
   commands:
   - dapper integration calico
   privileged: true
@@ -159,7 +147,7 @@ steps:
 
 - name: integration-weave
   pull: default
-  image: rancher/dapper:1.11.2
+  image: rancher/dapper:v0.6.0
   commands:
   - dapper integration weave
   privileged: true

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,26 +1,11 @@
-FROM ubuntu:20.04
-# FROM arm=armhf/ubuntu:20.04 arm64=arm64v8/ubuntu:20.04
+FROM registry.suse.com/bci/golang:1.19-20.16
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
-RUN apt-get update && \
-    apt-get install -y gcc ca-certificates git wget curl vim less file kmod iptables xz-utils zip && \
-    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+RUN zypper -n in docker awk
 
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
-    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-
-RUN wget -O - https://storage.googleapis.com/golang/go1.19.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
-
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2
-
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
-    DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
-    DOCKER_URL=DOCKER_URL_${ARCH}
-
-RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.1
 
 ENV DAPPER_SOURCE /go/src/github.com/rancher/rke/
 ENV DAPPER_RUN_ARGS --privileged -v /var/lib/docker

--- a/dind/dind.go
+++ b/dind/dind.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DINDImage           = "docker:19.03.12-dind"
+	DINDImage           = "docker:20.10.23-dind"
 	DINDContainerPrefix = "rke-dind"
 	DINDPlane           = "dind"
 	DINDNetwork         = "dind-network"
@@ -66,7 +66,7 @@ func StartUpDindContainer(ctx context.Context, dindAddress, dindNetwork, dindSto
 				"mount --make-shared / && " +
 					"mount --make-shared /sys && " +
 					"mount --make-shared /var/lib/docker && " +
-					"dockerd-entrypoint.sh --storage-driver=" + storageDriver,
+					"dockerd-entrypoint.sh --tls=false --storage-driver=" + storageDriver,
 			},
 			Hostname: dindAddress,
 			Env:      []string{"DOCKER_TLS_CERTDIR="},

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,0 @@
-FROM ubuntu:20.04
-COPY rke /usr/bin/
-CMD ["rke"]

--- a/scripts/package
+++ b/scripts/package
@@ -10,23 +10,3 @@ SUFFIX=""
 [ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 
 ./scripts/create-releasenote.sh
-
-cd package
-
-TAG=${TAG:-${VERSION}${SUFFIX}}
-REPO=${REPO:-rke}
-
-if echo $TAG | grep -q dirty; then
-    TAG=dev
-fi
-
-if [ -n "$DRONE_TAG" ]; then
-    TAG=$DRONE_TAG
-fi
-
-cp ../bin/rke .
-
-IMAGE=${REPO}/rke:${TAG}
-docker build -t ${IMAGE} .
-echo ${IMAGE} > ../dist/images
-echo Built ${IMAGE}

--- a/scripts/test
+++ b/scripts/test
@@ -7,6 +7,5 @@ echo Running tests
 
 PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
 
-[ "${ARCH}" == "amd64" ] && RACE=-race
-go test ${RACE} -cover -tags=test ${PACKAGES}
+go test -cover -tags=test ${PACKAGES}
 


### PR DESCRIPTION
- Moves to BCI for building
- Bumps docker-dind image used for testing
- Removes creating a Docker image for RKE as we are not publishing/using it
- Removes the race flag for testing as it requires an additional package in BCI and we don't use it anywhere else, if we would like to keep it, we can add the package (which then need to be kept up-to-date as well when we bump Go)

This also prepares the repository so we can keep it up-to-date automatically with Renovate in the future.

We can also postpone this PR to 1.5.x if wanted.