### PR TITLE
drop the checks for PSP resources in the cluster

### DIFF
--- a/k8s/psp.go
+++ b/k8s/psp.go
@@ -30,9 +30,3 @@ func updatePodSecurityPolicy(k8sClient *kubernetes.Clientset, p interface{}) err
 	return nil
 
 }
-
-// GetPSPList returns the PodSecurityPolicyList containing all PSPs in the cluster and an error.
-// The list could be empty if there is no PSP in the cluster.
-func GetPSPList(k8sClient *kubernetes.Clientset) (*v1beta1.PodSecurityPolicyList, error) {
-	return k8sClient.PolicyV1beta1().PodSecurityPolicies().List(context.TODO(), metav1.ListOptions{})
-}


### PR DESCRIPTION
Issue https://github.com/rancher/rancher/issues/40652

This PR drops the checks for PSP resources in the cluster.

Here is the original PR for adding such checks : https://github.com/rancher/rke/pull/3132

