### PR TITLE
[v1.4.4] Switch to release-2.7

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/dev-v2.7/data.json"
+	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/release-v2.7/data.json"
 	dataFile   = "data/data.json"
 )
 
-// Codegen fetch data.json from https://releases.rancher.com/kontainer-driver-metadata/release-v2.6/data.json and generates bindata
+// Codegen fetch data.json from https://releases.rancher.com/kontainer-driver-metadata/release-v2.7/data.json and generates bindata
 func main() {
 	u := os.Getenv(metadata.RancherMetadataURLEnv)
 	if u == "" {


### PR DESCRIPTION
`go generate` did not result in a new `data.json`, likely due to the recent RC that was cut ~1 week ago. Running a diff against the `data.json` in the repository and the one from `releases.rancher.com` shows that they match 