### PR TITLE
Add support for custom certificate life/expiration.

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -144,6 +144,8 @@ const (
 	DefaultHTTPSPort                  = 443
 	DefaultNetworkMode                = "hostNetwork"
 	DefaultNetworkModeV121            = "hostPort"
+
+	DefaultCertificateLifetime = 365 * 10
 )
 
 var (
@@ -1058,6 +1060,9 @@ func (c *Cluster) setAddonsDefaults() {
 	if c.Ingress.DefaultIngressClass == nil {
 		defaultIngressClass := true
 		c.Ingress.DefaultIngressClass = &defaultIngressClass
+	}
+	if c.CertificateLifetime == 0 {
+		c.CertificateLifetime = DefaultCertificateLifetime
 	}
 }
 

--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -250,6 +250,10 @@ func rotateRKECertificates(ctx context.Context, kubeCluster *cluster.Cluster, fl
 		if _, err := caCert.Verify(x509.VerifyOptions{Roots: certPool, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}}); err != nil {
 			return nil, fmt.Errorf("Failed to rotate certificates: CA certificate is invalid, please use the --rotate-ca flag to rotate CA certificate, error: %v", err)
 		}
+		// Update the current-state cert-lifetime to the desired state for rotation.
+		if kubeCluster.CertificateLifetime != 0 {
+			currentCluster.CertificateLifetime = kubeCluster.CertificateLifetime
+		}
 	}
 	if err := cluster.RotateRKECertificates(ctx, currentCluster, flags, rkeFullState); err != nil {
 		return nil, err

--- a/pki/cert/cert.go
+++ b/pki/cert/cert.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	rsaKeySize   = 2048
-	duration1d = time.Hour *24
+	duration1d   = time.Hour * 24
 	duration365d = duration1d * 365
 )
 

--- a/pki/constants.go
+++ b/pki/constants.go
@@ -36,5 +36,7 @@ const (
 	KubeAdminCertName         = "kube-admin"
 	KubeAdminOrganizationName = "system:masters"
 	KubeAdminConfigPrefix     = "kube_config_"
-	duration365d              = time.Hour * 24 * 365
+
+	duration1d   = time.Hour * 24
+	duration365d = duration1d * 365
 )

--- a/pki/pki.go
+++ b/pki/pki.go
@@ -90,7 +90,7 @@ func RegenerateEtcdCertificate(
 	caKey := crtMap[CACertName].Key
 	etcdAltNames := GetAltNames(etcdHosts, clusterDomain, KubernetesServiceIP, []string{})
 
-	etcdCrt, etcdKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, EtcdCertName, etcdAltNames, nil, nil)
+	etcdCrt, etcdKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, EtcdCertName, etcdAltNames, nil, nil, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pki/pki_test.go
+++ b/pki/pki_test.go
@@ -25,6 +25,7 @@ func TestPKI(t *testing.T) {
 				HostnameOverride: "server1",
 			},
 		},
+		CertificateLifetime: 30,
 		Services: v3.RKEConfigServices{
 			KubeAPI: v3.KubeAPIService{
 				ServiceClusterIPRange: FakeClusterCidr,

--- a/pki/services.go
+++ b/pki/services.go
@@ -40,7 +40,7 @@ func GenerateKubeAPICertificate(ctx context.Context, certs map[string]Certificat
 	if !rotate {
 		serviceKey = certs[KubeAPICertName].Key
 	}
-	kubeAPICrt, kubeAPIKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, KubeAPICertName, kubeAPIAltNames, serviceKey, nil)
+	kubeAPICrt, kubeAPIKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, KubeAPICertName, kubeAPIAltNames, serviceKey, nil, rkeConfig.CertificateLifetime)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func GenerateKubeControllerCertificate(ctx context.Context, certs map[string]Cer
 	if !rotate {
 		serviceKey = certs[KubeControllerCertName].Key
 	}
-	kubeControllerCrt, kubeControllerKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, getDefaultCN(KubeControllerCertName), nil, serviceKey, nil)
+	kubeControllerCrt, kubeControllerKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, getDefaultCN(KubeControllerCertName), nil, serviceKey, nil, rkeConfig.CertificateLifetime)
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func GenerateKubeSchedulerCertificate(ctx context.Context, certs map[string]Cert
 	if !rotate {
 		serviceKey = certs[KubeSchedulerCertName].Key
 	}
-	kubeSchedulerCrt, kubeSchedulerKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, getDefaultCN(KubeSchedulerCertName), nil, serviceKey, nil)
+	kubeSchedulerCrt, kubeSchedulerKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, getDefaultCN(KubeSchedulerCertName), nil, serviceKey, nil, rkeConfig.CertificateLifetime)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func GenerateKubeProxyCertificate(ctx context.Context, certs map[string]Certific
 	if !rotate {
 		serviceKey = certs[KubeProxyCertName].Key
 	}
-	kubeProxyCrt, kubeProxyKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, getDefaultCN(KubeProxyCertName), nil, serviceKey, nil)
+	kubeProxyCrt, kubeProxyKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, getDefaultCN(KubeProxyCertName), nil, serviceKey, nil, rkeConfig.CertificateLifetime)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func GenerateKubeNodeCertificate(ctx context.Context, certs map[string]Certifica
 	if !rotate {
 		serviceKey = certs[KubeProxyCertName].Key
 	}
-	nodeCrt, nodeKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, KubeNodeCommonName, nil, serviceKey, []string{KubeNodeOrganizationName})
+	nodeCrt, nodeKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, KubeNodeCommonName, nil, serviceKey, []string{KubeNodeOrganizationName}, rkeConfig.CertificateLifetime)
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func GenerateKubeAdminCertificate(ctx context.Context, certs map[string]Certific
 	if !rotate {
 		serviceKey = certs[KubeAdminCertName].Key
 	}
-	kubeAdminCrt, kubeAdminKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, KubeAdminCertName, nil, serviceKey, []string{KubeAdminOrganizationName})
+	kubeAdminCrt, kubeAdminKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, KubeAdminCertName, nil, serviceKey, []string{KubeAdminOrganizationName}, rkeConfig.CertificateLifetime)
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func GenerateAPIProxyClientCertificate(ctx context.Context, certs map[string]Cer
 	if !rotate {
 		serviceKey = certs[APIProxyClientCertName].Key
 	}
-	apiserverProxyClientCrt, apiserverProxyClientKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, APIProxyClientCertName, nil, serviceKey, nil)
+	apiserverProxyClientCrt, apiserverProxyClientKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, APIProxyClientCertName, nil, serviceKey, nil, rkeConfig.CertificateLifetime)
 	if err != nil {
 		return err
 	}
@@ -398,7 +398,7 @@ func GenerateEtcdCertificates(ctx context.Context, certs map[string]CertificateP
 			serviceKey = certs[etcdName].Key
 		}
 		logrus.Infof("[certificates] Generating %s certificate and key", etcdName)
-		etcdCrt, etcdKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, EtcdCertName, etcdAltNames, serviceKey, nil)
+		etcdCrt, etcdKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, EtcdCertName, etcdAltNames, serviceKey, nil, rkeConfig.CertificateLifetime)
 		if err != nil {
 			return err
 		}
@@ -451,7 +451,7 @@ func GenerateServiceTokenKey(ctx context.Context, certs map[string]CertificatePK
 	if certs[ServiceAccountTokenKeyName].Key == nil {
 		privateAPIKey = certs[KubeAPICertName].Key
 	}
-	tokenCrt, tokenKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, ServiceAccountTokenKeyName, nil, privateAPIKey, nil)
+	tokenCrt, tokenKey, err := GenerateSignedCertAndKey(caCrt, caKey, false, ServiceAccountTokenKeyName, nil, privateAPIKey, nil, 0)
 	if err != nil {
 		return fmt.Errorf("Failed to generate private key for service account token: %v", err)
 	}
@@ -515,7 +515,7 @@ func GenerateKubeletCertificate(ctx context.Context, certs map[string]Certificat
 			serviceKey = certs[kubeletName].Key
 		}
 		log.Debugf(ctx, "[certificates] Generating %s certificate and key", kubeletName)
-		kubeletCrt, kubeletKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, kubeletName, kubeletAltNames, serviceKey, nil)
+		kubeletCrt, kubeletKey, err := GenerateSignedCertAndKey(caCrt, caKey, true, kubeletName, kubeletAltNames, serviceKey, nil, rkeConfig.CertificateLifetime)
 		if err != nil {
 			return err
 		}

--- a/types/rke_types.go
+++ b/types/rke_types.go
@@ -66,6 +66,8 @@ type RancherKubernetesEngineConfig struct {
 	DNS *DNSConfig `yaml:"dns" json:"dns,omitempty"`
 	// Upgrade Strategy for the cluster
 	UpgradeStrategy *NodeUpgradeStrategy `yaml:"upgrade_strategy,omitempty" json:"upgradeStrategy,omitempty"`
+	// CertLifetime identify the lifetime of generated certificates in days for corporate compliance
+	CertificateLifetime int `yaml:"certificate_lifetime" json:"certificateLifetime,omitempty"`
 }
 
 func (r *RancherKubernetesEngineConfig) ObjClusterName() string {


### PR DESCRIPTION
This pull request adds support to RKE to allow the configuration of certificate lifetime/expiration to support typical corporate requirements for shorter certificate expiration.

This change acknowledges that the default certificate lifetime for cluster certificates is ~10 years and makes no change to that default. Instead it adds support for a `cluster.yml` configuration option called `certificate_lifetime`. The `certificate_lifetime` option accepts an integer being a number of days from the current date for which certificates will be valid. This logic is respected during both the creation of a new cluster or during certificate rotation. This modification does not make any changes to the CA's created by RKE.