### PR TITLE
[release/v1.4] Add env var to enable dual-stack in cri-dockerd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	k8s.io/kubectl v0.25.4
 	k8s.io/kubernetes v1.13.0
 	k8s.io/pod-security-admission v0.25.4
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -147,7 +148,6 @@ require (
 	k8s.io/component-base v0.25.4 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect


### PR DESCRIPTION
https://github.com/rancher/rke/issues/3271

The flag to enable cri-dockerd to work properly with dual-stack was missing, this PR adds another environment variable to the container to instruct the entrypoint in rke-tools (https://github.com/rancher/rke-tools/pull/163) to configure the needed flag.

As there is no good way to detect multiple CIDR/dual-stack inside the container itself, we need to instruct the container via an environment variable after checking the cluster configuration (`cluster-cidr` flag containing more than one CIDR)

I wanted to add IPv6 tests to `scripts/integration` but because the DinD setup, this needs a lot more work to enable IPv6 and make the test pass.