### PR TITLE
KDM Out Of Band Update For June 2023 - Rancher v2.7

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/dev-v2.7-2023-06-patches/data.json"
+	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/release-v2.7/data.json"
 	dataFile   = "data/data.json"
 )
 


### PR DESCRIPTION
There are no data.json changes in this PR due to https://github.com/rancher/rke/pull/3283, which generated the file ~2 hours ago and matches the contents in the KDM repo. This PR just swaps the KDM url to release-v2.7