### PR TITLE
Set the default PodSecurityConfiguration value only if the cluster's k8s version is at least 1.23

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -404,8 +404,15 @@ func (c *Cluster) setClusterServicesDefaults() {
 			c.Services.KubeAPI.EventRateLimit.Configuration == nil {
 			c.Services.KubeAPI.EventRateLimit.Configuration = newDefaultEventRateLimitConfig()
 		}
-		if len(c.Services.KubeAPI.PodSecurityConfiguration) == 0 {
-			c.Services.KubeAPI.PodSecurityConfiguration = PodSecurityPrivileged
+		parsedVersion, err := getClusterVersion(c.Version)
+		if err != nil {
+			logrus.Warnf("Can not parse the cluster version [%s] to determine wether to set the default PodSecurityConfiguration: %v", c.Version, err)
+		} else {
+			if parsedRangeAtLeast123(parsedVersion) {
+				if len(c.Services.KubeAPI.PodSecurityConfiguration) == 0 {
+					c.Services.KubeAPI.PodSecurityConfiguration = PodSecurityPrivileged
+				}
+			}
 		}
 	}
 

--- a/cluster/hosts.go
+++ b/cluster/hosts.go
@@ -167,11 +167,17 @@ func (c *Cluster) getConsolidatedAdmissionConfiguration() (*apiserverv1.Admissio
 	_ = setPluginConfiguration(admissionConfig, ertConfig)
 
 	// PodSecurity
-	psConfig, err := c.getPodSecurityAdmissionPluginConfiguration()
+	parsedVersion, err := getClusterVersion(c.Version)
 	if err != nil {
 		return nil, err
 	}
-	_ = setPluginConfiguration(admissionConfig, psConfig)
+	if parsedRangeAtLeast123(parsedVersion) {
+		psConfig, err := c.getPodSecurityAdmissionPluginConfiguration()
+		if err != nil {
+			return nil, err
+		}
+		_ = setPluginConfiguration(admissionConfig, psConfig)
+	}
 
 	return admissionConfig, nil
 }


### PR DESCRIPTION
This PR is to add [this PR](https://github.com/rancher/rke/pull/3261) back.  
The original PR was reverted because the linked issue was moved out of the scope of RKE v1.4.6. 

Below is a copy of the original PR's description:

 
# Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

https://github.com/rancher/rke/issues/3247
https://github.com/rancher/rancher/issues/41292

# Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->
 
The issue is reported in Rancher at first, but the root cause is in RKE. 

When RKE initializes the cluster, it sets the default value to the field `spec.Services.KubeAPI.PodSecurityConfiguration` when no value is provided in the cluster.yml file (see [code](https://github.com/rancher/rke/blob/5d360491203a3c1511aa6d12c496679dea05ba37/cluster/defaults.go#L398-L400)) **regardless of the cluster's Kubernetes version**.

But later on, when RKE validates the cluster's configuration before starting the upgrading, it expects to see the abovementioned field to be set only for clusters whose k8s version is **at least 1.23** (see [code](https://github.com/rancher/rke/blob/5d360491203a3c1511aa6d12c496679dea05ba37/cluster/validation.go#L691-L703)). Therefore the following error is returned: 
```
FATA[0000] Failed to validate cluster: cluster version must be at least v1.23 to use PodSecurity in RKE
```

To reproduce the bug, we can use RKE CLI v1.4.5 to provision a cluster with k8s version 1.22.17-rancher1-2, although the version is not officially supported by RKE CLI v1.4.5. 

```
// cluster.yaml
nodes:
  - address: xxx
    internal_address: xxx
    user: ubuntu
    role: [controlplane,worker,etcd]
kubernetes_version: v1.22.17-rancher1-2
```

# Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Check the cluster k8s version and set the default PodSecurityConfiguration value only if the cluster's k8s version is at least 1.23

After this PR is merged, a following PR need to be raised in Rancher to bump the RKE module. 

# Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->


Follow the same steps to provision a cluster with k8s version `1.22.17-rancher1-2` using the RKE binary compiled from this branch. The cluster is provisioned successfully. Also, if we ssh into the node to check the file `/etc/kubernetes/admission.yaml`, we can see that the default PodSecurity Configuration is not in the file, which is expected. 
