### PR TITLE
[release v1.4] Add missing calico logs volumeMount

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -52,13 +52,16 @@ const (
 	KubeletDockerConfigPath    = "/var/lib/kubelet/config.json"
 
 	// MaxEtcdOldEnvVersion The versions are maxed out for minor versions because -rancher1 suffix will cause semver to think its older, example: v1.15.0 > v1.15.0-rancher1
-	MaxEtcdOldEnvVersion      = "v3.2.99"
-	MaxK8s115Version          = "v1.15"
-	MaxEtcdPort4001Version    = "v3.4.3-rancher99"
-	MaxEtcdNoStrictTLSVersion = "v3.4.14-rancher99"
-	MaxK8s121Version          = "v1.21.99-rancher99"
-	MaxK8s122Version          = "v1.22.99-rancher99"
-
+	MaxEtcdOldEnvVersion             = "v3.2.99"
+	MaxK8s115Version                 = "v1.15"
+	MaxEtcdPort4001Version           = "v3.4.3-rancher99"
+	MaxEtcdNoStrictTLSVersion        = "v3.4.14-rancher99"
+	MaxK8s121Version                 = "v1.21.99-rancher99"
+	MaxK8s122Version                 = "v1.22.99-rancher99"
+	JanK8s123Version                 = "v1.23.16-rancher2-3"
+	JulyK8s124Version                = "1.24.16-rancher1-1"
+	JulyK8s125Version                = "1.25.12-rancher1-1"
+	JulyK8s126Version                = "1.26.7-rancher1-1"
 	EncryptionProviderConfigArgument = "encryption-provider-config"
 
 	KubeletCRIDockerdNameEnv = "RKE_KUBELET_CRIDOCKERD"
@@ -558,6 +561,33 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, serviceOptions v3.Kubern
 			fmt.Sprintf("%s:c:/host/run", path.Join(host.PrefixPath, "/run")),
 		}...)
 	} else {
+		parsedVersion, err := getClusterVersion(c.Version)
+		if err != nil {
+			logrus.Debugf("Error while parsing cluster version: %s", err)
+		}
+		parsedJanK8s123Version, err := getClusterVersion(JanK8s123Version)
+		if err != nil {
+			logrus.Debugf("Error while parsing cluster version: %s", err)
+		}
+		parsedJulyK8s124Version, err := getClusterVersion(JulyK8s124Version)
+		if err != nil {
+			logrus.Debugf("Error while parsing cluster version: %s", err)
+		}
+		parsedJulyK8s125Version, err := getClusterVersion(JulyK8s125Version)
+		if err != nil {
+			logrus.Debugf("Error while parsing cluster version: %s", err)
+		}
+		parsedJulyK8s126Version, err := getClusterVersion(JulyK8s126Version)
+		if err != nil {
+			logrus.Debugf("Error while parsing cluster version: %s", err)
+		}
+		if (parsedVersion.Major == parsedJanK8s123Version.Major && parsedVersion.Minor == parsedJanK8s123Version.Minor && parsedVersion.GE(parsedJanK8s123Version)) ||
+			(parsedVersion.Major == parsedJulyK8s124Version.Major && parsedVersion.Minor == parsedJulyK8s124Version.Minor && parsedVersion.GE(parsedJulyK8s124Version)) ||
+			(parsedVersion.Major == parsedJulyK8s125Version.Major && parsedVersion.Minor == parsedJulyK8s125Version.Minor && parsedVersion.GE(parsedJulyK8s125Version)) ||
+			parsedVersion.GE(parsedJulyK8s126Version) {
+			Binds = append(Binds, "/var/log/calico/cni:/var/log/calico/cni:z")
+		}
+
 		Binds = append(Binds, []string{
 			fmt.Sprintf("%s:/etc/kubernetes:z", path.Join(host.PrefixPath, "/etc/kubernetes")),
 			"/etc/cni:/etc/cni:rw,z",
@@ -575,7 +605,6 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, serviceOptions v3.Kubern
 			"/dev:/host/dev:rprivate",
 			"/var/log/containers:/var/log/containers:z",
 			"/var/log/pods:/var/log/pods:z",
-			"/var/log/calico/cni:/var/log/calico/cni:z",
 			"/usr:/host/usr:ro",
 			"/etc:/host/etc:ro",
 		}...)

--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -575,6 +575,7 @@ func (c *Cluster) BuildKubeletProcess(host *hosts.Host, serviceOptions v3.Kubern
 			"/dev:/host/dev:rprivate",
 			"/var/log/containers:/var/log/containers:z",
 			"/var/log/pods:/var/log/pods:z",
+			"/var/log/calico/cni:/var/log/calico/cni:z",
 			"/usr:/host/usr:ro",
 			"/etc:/host/etc:ro",
 		}...)


### PR DESCRIPTION
There was a missing volumeMount which was causing the calico/canal logs getting written to the container overlay filesystem causing the container to fill up. Adding the missing bind resolves this issue.

Linked issue: https://github.com/rancher/rancher/issues/40330