### PR TITLE
[Backport] Set the default PodSecurityConfiguration value only if the cluster's k8s version is at least 1.23

### DIFF
--- a/cluster/defaults.go
+++ b/cluster/defaults.go
@@ -404,8 +404,15 @@ func (c *Cluster) setClusterServicesDefaults() {
 			c.Services.KubeAPI.EventRateLimit.Configuration == nil {
 			c.Services.KubeAPI.EventRateLimit.Configuration = newDefaultEventRateLimitConfig()
 		}
-		if len(c.Services.KubeAPI.PodSecurityConfiguration) == 0 {
-			c.Services.KubeAPI.PodSecurityConfiguration = PodSecurityPrivileged
+		parsedVersion, err := getClusterVersion(c.Version)
+		if err != nil {
+			logrus.Warnf("Can not parse the cluster version [%s] to determine wether to set the default PodSecurityConfiguration: %v", c.Version, err)
+		} else {
+			if parsedRangeAtLeast123(parsedVersion) {
+				if len(c.Services.KubeAPI.PodSecurityConfiguration) == 0 {
+					c.Services.KubeAPI.PodSecurityConfiguration = PodSecurityPrivileged
+				}
+			}
 		}
 	}
 

--- a/cluster/hosts.go
+++ b/cluster/hosts.go
@@ -167,11 +167,17 @@ func (c *Cluster) getConsolidatedAdmissionConfiguration() (*apiserverv1.Admissio
 	_ = setPluginConfiguration(admissionConfig, ertConfig)
 
 	// PodSecurity
-	psConfig, err := c.getPodSecurityAdmissionPluginConfiguration()
+	parsedVersion, err := getClusterVersion(c.Version)
 	if err != nil {
 		return nil, err
 	}
-	_ = setPluginConfiguration(admissionConfig, psConfig)
+	if parsedRangeAtLeast123(parsedVersion) {
+		psConfig, err := c.getPodSecurityAdmissionPluginConfiguration()
+		if err != nil {
+			return nil, err
+		}
+		_ = setPluginConfiguration(admissionConfig, psConfig)
+	}
 
 	return admissionConfig, nil
 }


### PR DESCRIPTION
GH issue https://github.com/rancher/rancher/issues/42127

Backport of the PR https://github.com/rancher/rke/pull/3291