### PR TITLE
Use correct container name in log

### DIFF
--- a/services/etcd.go
+++ b/services/etcd.go
@@ -476,7 +476,7 @@ func RunEtcdSnapshotSave(ctx context.Context, etcdHost *hosts.Host, prsMap map[s
 
 		return docker.RemoveContainer(ctx, etcdHost.DClient, etcdHost.Address, EtcdSnapshotOnceContainerName)
 	}
-	log.Infof(ctx, "[etcd] Running rolling snapshot container [%s] on host [%s]", EtcdSnapshotOnceContainerName, etcdHost.Address)
+	log.Infof(ctx, "[etcd] Running rolling snapshot container [%s] on host [%s]", EtcdSnapshotContainerName, etcdHost.Address)
 	logrus.Debugf("[etcd] Using command [%s] for rolling snapshot container [%s] on host [%s]", getSanitizedSnapshotCmd(imageCfg, es.BackupConfig), EtcdSnapshotContainerName, etcdHost.Address)
 	if err := docker.DoRemoveContainer(ctx, etcdHost.DClient, EtcdSnapshotContainerName, etcdHost.Address); err != nil {
 		return err


### PR DESCRIPTION
While working on documentation, I found this log line that uses the `etcd-snapshot-once` container name incorrectly as the code for running it once is in the part above and is returned. See log lines for how it is currently below, where the container name is different between the info and the debug log line.

```
time="2023-08-02T20:01:01+02:00" level=info msg="[etcd] Running rolling snapshot container [etcd-snapshot-once] on host [52.13.57.129]"
time="2023-08-02T20:01:01+02:00" level=debug msg="[etcd] Using command [/opt/rke-tools/rke-etcd-backup etcd-backup save --cacert /etc/kubernetes/ssl/kube-ca.pem --cert /etc/kubernetes/ssl/kube-node.pem --key /etc/kubernetes/ssl/kube-node-key.pem --name etcd-rolling-snapshots --endpoints=172.26.14.216:2379 --retention=72h --creation=12h] for rolling snapshot container [etcd-rolling-snapshots] on host [52.13.57.129]"
```

The correct container name is `etcd-rolling-snapshots`