### PR TITLE
Replace deprecated io/ioutil

### DIFF
--- a/cluster/addons.go
+++ b/cluster/addons.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -260,7 +260,7 @@ func (c *Cluster) deployAddonsInclude(ctx context.Context) error {
 
 			manifests = append(manifests, addonYAML...)
 		} else if isFilePath(addon) {
-			addonYAML, err := ioutil.ReadFile(addon)
+			addonYAML, err := os.ReadFile(addon)
 			if err != nil {
 				return err
 			}
@@ -324,7 +324,7 @@ func getAddonFromURL(yamlURL string) ([]byte, error) {
 
 	defer resp.Body.Close()
 
-	addonYaml, err := ioutil.ReadAll(resp.Body)
+	addonYaml, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return nil, err

--- a/cluster/state.go
+++ b/cluster/state.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -271,7 +271,7 @@ func ReadStateFile(ctx context.Context, statePath string) (*FullState, error) {
 		return rkeFullState, fmt.Errorf("Can not find RKE state file: %v", err)
 	}
 	defer file.Close()
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return rkeFullState, fmt.Errorf("failed to read state file: %v", err)
 	}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,7 +40,7 @@ func resolveClusterFile(ctx *cli.Context) (string, string, error) {
 		return "", "", fmt.Errorf("can not find cluster configuration file: %v", err)
 	}
 	defer file.Close()
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to read file: %v", err)
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
@@ -97,7 +96,7 @@ func writeConfig(cluster *v3.RancherKubernetesEngineConfig, configFile string, p
 		fmt.Printf("Configuration File: \n%s", configString)
 		return nil
 	}
-	return ioutil.WriteFile(configFile, []byte(configString), 0640)
+	return os.WriteFile(configFile, []byte(configString), 0640)
 }
 
 func clusterConfig(ctx *cli.Context) error {

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -26,13 +26,13 @@ func main() {
 	}
 	defer data.Body.Close()
 
-	b, err := ioutil.ReadAll(data.Body)
+	b, err := io.ReadAll(data.Body)
 	if err != nil {
 		panic(err)
 	}
 
 	fmt.Println("Writing data")
-	if err := ioutil.WriteFile(dataFile, b, 0755); err != nil {
+	if err := os.WriteFile(dataFile, b, 0755); err != nil {
 		return
 	}
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -311,7 +310,7 @@ func pullImage(ctx context.Context, dClient *client.Client, hostname string, con
 		if logrus.GetLevel() == logrus.TraceLevel {
 			io.Copy(os.Stdout, out)
 		} else {
-			io.Copy(ioutil.Discard, out)
+			io.Copy(io.Discard, out)
 		}
 		return nil
 	}
@@ -647,7 +646,7 @@ func ReadFileFromContainer(ctx context.Context, dClient *client.Client, hostname
 	if _, err := tarReader.Next(); err != nil {
 		return "", err
 	}
-	file, err := ioutil.ReadAll(tarReader)
+	file, err := io.ReadAll(tarReader)
 	if err != nil {
 		return "", err
 	}

--- a/hosts/tunnel.go
+++ b/hosts/tunnel.go
@@ -3,7 +3,6 @@ package hosts
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -136,7 +135,7 @@ func privateKeyPath(sshKeyPath string) (string, error) {
 	if sshKeyPath[:2] == "~/" {
 		sshKeyPath = filepath.Join(userHome(), sshKeyPath[2:])
 	}
-	buff, err := ioutil.ReadFile(sshKeyPath)
+	buff, err := os.ReadFile(sshKeyPath)
 	if err != nil {
 		return "", fmt.Errorf("Error while reading SSH key file: %v", err)
 	}
@@ -147,7 +146,7 @@ func certificatePath(sshCertPath string) (string, error) {
 	if sshCertPath[:2] == "~/" {
 		sshCertPath = filepath.Join(userHome(), sshCertPath[2:])
 	}
-	buff, err := ioutil.ReadFile(sshCertPath)
+	buff, err := os.ReadFile(sshCertPath)
 	if err != nil {
 		return "", fmt.Errorf("Error while reading SSH certificate file: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 
@@ -34,7 +34,7 @@ func mainErr() error {
 	app.Usage = "Rancher Kubernetes Engine, an extremely simple, lightning fast Kubernetes installer that works everywhere"
 	app.Before = func(ctx *cli.Context) error {
 		if ctx.GlobalBool("quiet") {
-			logrus.SetOutput(ioutil.Discard)
+			logrus.SetOutput(io.Discard)
 		} else {
 			if ctx.GlobalBool("debug") {
 				logrus.SetLevel(logrus.DebugLevel)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -85,9 +85,9 @@ func readFile(file string) ([]byte, error) {
 			return nil, err
 		}
 		defer resp.Body.Close()
-		return ioutil.ReadAll(resp.Body)
+		return io.ReadAll(resp.Body)
 	}
-	return ioutil.ReadFile(file)
+	return os.ReadFile(file)
 }
 
 const RKEVersionDev = "v1.4.99"

--- a/pki/cert/io.go
+++ b/pki/cert/io.go
@@ -19,7 +19,6 @@ package cert
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -66,7 +65,7 @@ func WriteCert(certPath string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(certPath), os.FileMode(0755)); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(certPath, data, os.FileMode(0644))
+	return os.WriteFile(certPath, data, os.FileMode(0644))
 }
 
 // WriteKey writes the pem-encoded key data to keyPath.
@@ -77,13 +76,13 @@ func WriteKey(keyPath string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(keyPath), os.FileMode(0755)); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(keyPath, data, os.FileMode(0600))
+	return os.WriteFile(keyPath, data, os.FileMode(0600))
 }
 
 // LoadOrGenerateKeyFile looks for a key in the file at the given path. If it
 // can't find one, it will generate a new key and store it there.
 func LoadOrGenerateKeyFile(keyPath string) (data []byte, wasGenerated bool, err error) {
-	loadedData, err := ioutil.ReadFile(keyPath)
+	loadedData, err := os.ReadFile(keyPath)
 	if err == nil {
 		return loadedData, false, err
 	}
@@ -118,7 +117,7 @@ func NewPool(filename string) (*x509.CertPool, error) {
 // CertsFromFile returns the x509.Certificates contained in the given PEM-encoded file.
 // Returns an error if the file could not be read, a certificate could not be parsed, or if the file does not contain any certificates
 func CertsFromFile(file string) ([]*x509.Certificate, error) {
-	pemBlock, err := ioutil.ReadFile(file)
+	pemBlock, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +131,7 @@ func CertsFromFile(file string) ([]*x509.Certificate, error) {
 // PrivateKeyFromFile returns the private key in rsa.PrivateKey or ecdsa.PrivateKey format from a given PEM-encoded file.
 // Returns an error if the file could not be read or if the private key could not be parsed.
 func PrivateKeyFromFile(file string) (interface{}, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +145,7 @@ func PrivateKeyFromFile(file string) (interface{}, error) {
 // PublicKeysFromFile returns the public keys in rsa.PublicKey or ecdsa.PublicKey format from a given PEM-encoded file.
 // Reads public keys from both public and private key files.
 func PublicKeysFromFile(file string) ([]interface{}, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/pki/deploy.go
+++ b/pki/deploy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -209,7 +208,7 @@ func DeployAdminConfig(ctx context.Context, kubeConfig, localConfigPath string) 
 	}
 	logrus.Debugf("Deploying admin Kubeconfig locally at [%s]", localConfigPath)
 	logrus.Tracef("Deploying admin Kubeconfig locally: %s", kubeConfig)
-	err := ioutil.WriteFile(localConfigPath, []byte(kubeConfig), 0600)
+	err := os.WriteFile(localConfigPath, []byte(kubeConfig), 0600)
 	if err != nil {
 		return fmt.Errorf("Failed to create local admin kubeconfig file: %v", err)
 	}

--- a/pki/util.go
+++ b/pki/util.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"net"
@@ -558,7 +557,7 @@ func ReadCSRsAndKeysFromDir(certDir string) (map[string]CertificatePKI, error) {
 		return certMap, nil
 	}
 
-	files, err := ioutil.ReadDir(certDir)
+	files, err := os.ReadDir(certDir)
 	if err != nil {
 		return nil, err
 	}
@@ -590,7 +589,7 @@ func ReadCertsAndKeysFromDir(certDir string) (map[string]CertificatePKI, error) 
 		return certMap, nil
 	}
 
-	files, err := ioutil.ReadDir(certDir)
+	files, err := os.ReadDir(certDir)
 	if err != nil {
 		return nil, err
 	}
@@ -638,7 +637,7 @@ func getOUName(certName string) string {
 
 func getCertFromFile(certDir string, fileName string) (*x509.Certificate, error) {
 	var certificate *x509.Certificate
-	certPEM, _ := ioutil.ReadFile(filepath.Join(certDir, fileName))
+	certPEM, _ := os.ReadFile(filepath.Join(certDir, fileName))
 	if len(certPEM) > 0 {
 		logrus.Debugf("Certificate file [%s/%s] content is greater than 0", certDir, fileName)
 		certificates, err := cert.ParseCertsPEM(certPEM)
@@ -652,7 +651,7 @@ func getCertFromFile(certDir string, fileName string) (*x509.Certificate, error)
 
 func getKeyFromFile(certDir string, fileName string) (*rsa.PrivateKey, error) {
 	var key *rsa.PrivateKey
-	keyPEM, _ := ioutil.ReadFile(filepath.Join(certDir, fileName))
+	keyPEM, _ := os.ReadFile(filepath.Join(certDir, fileName))
 	if len(keyPEM) > 0 {
 		keyInterface, err := cert.ParsePrivateKeyPEM(keyPEM)
 		if err != nil {
@@ -664,7 +663,7 @@ func getKeyFromFile(certDir string, fileName string) (*rsa.PrivateKey, error) {
 }
 
 func getCSRFromFile(certDir string, fileName string) ([]byte, error) {
-	csrPEM, err := ioutil.ReadFile(filepath.Join(certDir, fileName))
+	csrPEM, err := os.ReadFile(filepath.Join(certDir, fileName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read csr [%s]: %v", fileName, err)
 	}
@@ -683,7 +682,7 @@ func WriteCertificates(certDirPath string, certBundle map[string]CertificatePKI)
 	for certName, cert := range certBundle {
 		if cert.CertificatePEM != "" {
 			certificatePath := filepath.Join(certDirPath, certName+".pem")
-			if err := ioutil.WriteFile(certificatePath, []byte(cert.CertificatePEM), 0640); err != nil {
+			if err := os.WriteFile(certificatePath, []byte(cert.CertificatePEM), 0640); err != nil {
 				return fmt.Errorf("Failed to write certificate to path %v: %v", certificatePath, err)
 			}
 			logrus.Debugf("Successfully Deployed certificate file at [%s]", certificatePath)
@@ -691,7 +690,7 @@ func WriteCertificates(certDirPath string, certBundle map[string]CertificatePKI)
 
 		if cert.KeyPEM != "" {
 			keyPath := filepath.Join(certDirPath, certName+"-key.pem")
-			if err := ioutil.WriteFile(keyPath, []byte(cert.KeyPEM), 0640); err != nil {
+			if err := os.WriteFile(keyPath, []byte(cert.KeyPEM), 0640); err != nil {
 				return fmt.Errorf("Failed to write key to path %v: %v", keyPath, err)
 			}
 			logrus.Debugf("Successfully Deployed key file at [%s]", keyPath)
@@ -699,7 +698,7 @@ func WriteCertificates(certDirPath string, certBundle map[string]CertificatePKI)
 
 		if cert.CSRPEM != "" {
 			csrPath := filepath.Join(certDirPath, certName+"-csr.pem")
-			if err := ioutil.WriteFile(csrPath, []byte(cert.CSRPEM), 0640); err != nil {
+			if err := os.WriteFile(csrPath, []byte(cert.CSRPEM), 0640); err != nil {
 				return fmt.Errorf("Failed to write csr to path %v: %v", csrPath, err)
 			}
 			logrus.Debugf("Successfully Deployed csr file at [%s]", csrPath)
@@ -789,7 +788,7 @@ func validateCAIssuer(rkeConfig *v3.RancherKubernetesEngineConfig, certBundle ma
 }
 
 func ReadCertToStr(file string) (string, error) {
-	certStr, err := ioutil.ReadFile(file)
+	certStr, err := os.ReadFile(file)
 	if err != nil {
 		return "", fmt.Errorf("failed to read certificate [%s]: %v", file, err)
 	}

--- a/services/etcd_util.go
+++ b/services/etcd_util.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -116,7 +116,7 @@ func getHealthEtcd(hc http.Client, host *hosts.Host, url string) (string, error)
 	if err != nil {
 		return healthy.Health, fmt.Errorf("failed to get /health for host [%s]: %v", host.Address, err)
 	}
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return healthy.Health, fmt.Errorf("failed to read response of /health for host [%s]: %v", host.Address, err)
 	}

--- a/services/healthcheck.go
+++ b/services/healthcheck.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -96,7 +96,7 @@ func getHealthz(client *http.Client, serviceName, hostAddress, url string) error
 		return fmt.Errorf("Failed to check %s for service [%s] on host [%s]: %v", url, serviceName, hostAddress, err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		statusBody, _ := ioutil.ReadAll(resp.Body)
+		statusBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("Service [%s] is not healthy on host [%s]. Response code: [%d], response body: %s", serviceName, hostAddress, resp.StatusCode, statusBody)
 	}
 	return nil

--- a/util/util.go
+++ b/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"reflect"
@@ -244,7 +243,7 @@ func ReplaceFileWithBackup(originalFile, prefixBackupFile string) error {
 	if !fileExists {
 		return nil
 	}
-	tmpfile, err := ioutil.TempFile(".", prefixBackupFile)
+	tmpfile, err := os.CreateTemp(".", prefixBackupFile)
 	if err != nil {
 		return err
 	}
@@ -280,7 +279,7 @@ func CopyFileWithPrefix(originalFile, prefixDestFile string) error {
 	}
 	defer source.Close()
 
-	destFile, err := ioutil.TempFile(".", prefixDestFile)
+	destFile, err := os.CreateTemp(".", prefixDestFile)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR removes the deprecated io/ioutil and replaces its calls with the recommended ones (mostly in os library)

WARNING
Code generated by go-bindata will still use `ioutil` because go-bindata is that old