### PR TITLE
switch to release-v2.7 for RKE v1.4.10 release

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/dev-v2.7/data.json"
+	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/release-v2.7/data.json"
 	dataFile   = "data/data.json"
 )
 


### PR DESCRIPTION
Running `go generate ./...` did not result in any changes