### PR TITLE
[release/v1.5] Proper description of deleting pods

### DIFF
--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -199,7 +199,7 @@ func rebuildClusterWithRotatedCertificates(ctx context.Context,
 	}
 
 	if kubeCluster.RotateCertificates.CACertificates {
-		if err := cluster.RestartClusterPods(ctx, kubeCluster); err != nil {
+		if err := cluster.DeleteClusterPods(ctx, kubeCluster); err != nil {
 			return APIURL, caCrt, clientCert, clientKey, nil, err
 		}
 	}

--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -245,7 +245,7 @@ func RestoreEtcdSnapshot(
 		log.Warnf(ctx, err.Error())
 	}
 
-	if err := cluster.RestartClusterPods(ctx, kubeCluster); err != nil {
+	if err := cluster.DeleteClusterPods(ctx, kubeCluster); err != nil {
 		return APIURL, caCrt, clientCert, clientKey, nil, err
 	}
 	if err := kubeCluster.RemoveOldNodes(ctx); err != nil {


### PR DESCRIPTION
Debugging another issue I saw this seems to be outdated.

- `network, ingress, and metrics` has been extended since the function was created
- There is no such thing as restart cluster pods, they are deleted so renamed function
- Add some extra debug logging