### PR TITLE
changed etcd restore image to rke-tools for etcd >=3.5.7

### DIFF
--- a/cluster/etcd_test.go
+++ b/cluster/etcd_test.go
@@ -1,0 +1,61 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rancher/rke/metadata"
+	"github.com/rancher/rke/types"
+	v3 "github.com/rancher/rke/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRestoreImage(t *testing.T) {
+	ctx := context.Background()
+
+	metadata.InitMetadata(ctx)
+
+	cluster := &Cluster{
+		RancherKubernetesEngineConfig: v3.RancherKubernetesEngineConfig{
+			SystemImages: types.RKESystemImages{
+				Etcd:   "rancher/mirrored-coreos-etcd:v3.5.7",
+				Alpine: "rancher/rke-tools:v0.1.90",
+			},
+		},
+	}
+
+	expectedRestoreImage := cluster.getBackupImage()
+	restoreImage := cluster.getRestoreImage()
+
+	assert.NotEmpty(t, restoreImage, "")
+	assert.Equal(t, expectedRestoreImage, restoreImage,
+		"expected restoreImage is different when etcd image version is v3.5.7")
+
+	cluster.SystemImages.Etcd = "rancher/mirrored-coreos-etcd:v3.5.8"
+
+	expectedRestoreImage = cluster.getBackupImage()
+	restoreImage = cluster.getRestoreImage()
+
+	assert.NotEmpty(t, restoreImage, "")
+	assert.Equal(t, expectedRestoreImage, restoreImage,
+		"expected restoreImage is different when etcd image version is greater than v3.5.7")
+
+	cluster.SystemImages.Etcd = "rancher/mirrored-coreos-etcd:v3.5.6"
+
+	expectedRestoreImage = cluster.SystemImages.Etcd
+	restoreImage = cluster.getRestoreImage()
+
+	assert.NotEmpty(t, restoreImage, "")
+	assert.Equal(t, expectedRestoreImage, restoreImage,
+		"expected restoreImage is different when etcd image version is less than v3.5.7")
+
+	// test for custom image
+	cluster.SystemImages.Etcd = "custom/mirrored-coreos-etcd:v3.5.7"
+
+	expectedRestoreImage = cluster.SystemImages.Etcd
+	restoreImage = cluster.getRestoreImage()
+
+	assert.NotEmpty(t, restoreImage, "")
+	assert.Equal(t, expectedRestoreImage, restoreImage,
+		"expected restoreImage is different when custom etcd image is used")
+}


### PR DESCRIPTION
issue: https://github.com/rancher/rke/issues/3382

since etcd is moved to distroless base image from v3.5.7  so **/bin/sh, mv and rm**  tools will not be present in etcd Image. which is required by the restore command. [ref](https://github.com/rancher/rke/blob/d2b01281f33970e5980d307935474dac6a9833cd/services/etcd.go#L652-L670) 
One solution for that is to use a custom image which has etcdctl as well as these other required tools.
Since in rke we use rke-tools image to create etcd snapshots, i have changed restore image to rke-tools as well. since rke-tools has etcdctl with the other required deps for that command.