### PR TITLE
In continuation to PR #3368, remove `stage-binaries` step in Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,18 +24,6 @@ steps:
     - pull_request
     - tag
 
-- name: stage-binaries
-  pull: default
-  image: rancher/dapper:v0.6.0
-  commands:
-  - "cp -r ./bin/* ./package/"
-  when:
-    event:
-    - tag
-    ref:
-      include:
-      - "refs/tags/*"
-
 - name: github_binary_prerelease
   pull: default
   image: plugins/github-release


### PR DESCRIPTION
## Issue:
* The package folder was removed while moving to BCI in PR #3368, but the same is still used in the `stage-binaries` step of the Drone CI configuration, which is causing the tag release CI to [fail](https://drone-publish.rancher.io/rancher/rke/1789/1/3) 

## Updates
* Removed the `stage-binaries` step as we move to BCI, the package folder, and in turn, the `stage-binaries` step is not required anymore.