### PR TITLE
Add support for `v1.5` and branch `release/v2.8`

### DIFF
--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -8,6 +8,9 @@ case $DRONE_TAG in
   "v1.4"*)
     ACTION_TARGET_BRANCH="release/v2.7"
     ;;
+  "v1.5"*)
+    ACTION_TARGET_BRANCH="release/v2.8"
+    ;;
   *)
     echo "Not a valid tag, not dispatching event"
     exit 0


### PR DESCRIPTION
## Issue
* A dispatch PR in [rancher/rancher](https://github.com/rancher/rancher) is not triggered when a new release tag is created for the `v1.5.x` version.

## Update
* Add support for `v1.5` and branch `release/v2.8` in dispatch script.