### PR TITLE
Clean/speed up Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,24 @@ platform:
   arch: amd64
 
 steps:
+- name: skipfiles
+  image: plugins/git
+  commands:
+  - export NAME=$(test $DRONE_BUILD_EVENT = pull_request && echo remotes/origin/${DRONE_COMMIT_BRANCH} || echo ${DRONE_COMMIT_SHA}~)
+  - export DIFF=$(git --no-pager diff --name-only $NAME | grep -v -f .droneignore);
+  - if [ -z "$DIFF" ]; then
+        echo "All files in PR are on ignore list";
+        exit 78;
+    else
+        echo "Some files in PR are not ignored, $DIFF";
+    fi;
+  when:
+    ref:
+      include:
+        - refs/heads/master
+        - refs/heads/release/v*
+        - refs/pull/**
+
 - name: ci
   pull: default
   image: rancher/dapper:v0.6.0
@@ -23,6 +41,19 @@ steps:
     event:
     - pull_request
     - tag
+
+- name: integration-ci
+  pull: default
+  image: rancher/dapper:v0.6.0
+  commands:
+  - dapper integration-ci
+  privileged: true
+  volumes:
+  - name: socket
+    path: /var/run/docker.sock
+  when:
+    event:
+    - pull_request
 
 - name: github_binary_prerelease
   pull: default
@@ -115,7 +146,6 @@ steps:
   when:
     event:
     - pull_request
-    - tag
 
 - name: integration-flannel
   pull: default
@@ -129,7 +159,6 @@ steps:
   when:
     event:
     - pull_request
-    - tag
 
 - name: integration-calico
   pull: default
@@ -143,7 +172,6 @@ steps:
   when:
     event:
     - pull_request
-    - tag
 
 - name: integration-weave
   pull: default
@@ -157,7 +185,6 @@ steps:
   when:
     event:
     - pull_request
-    - tag
 
 volumes:
 - name: socket

--- a/.droneignore
+++ b/.droneignore
@@ -1,0 +1,6 @@
+^.*\.md$
+^\.droneignore$
+^\.github\/.*$
+^CODEOWNERS$
+^LICENSE$
+^docs/.*$

--- a/scripts/integration-ci
+++ b/scripts/integration-ci
@@ -3,7 +3,5 @@ set -e
 
 cd $(dirname $0)
 
-./validate
 ./build
-./test
-./package
+./integration


### PR DESCRIPTION
https://github.com/rancher/rke/issues/3396

- Adds a `skipfiles` step taken from [rke2](https://github.com/rancher/rke2/blob/0f71c9a47b030bf152d541db52e85f05e2473ced/.drone.yml#L14), which will skip the pipeline if only non code changes are present (exitcode 78 skips the whole pipeline in Drone)
- Removes running `script/integration` in `scripts/ci`, adds `scripts/integration-ci` to be run as a separate step. This makes it possible to have it run on PR but not on tag.
- Removes all the other integration steps on tag as well, tagging is confirming an existing good state so we don't have to waste time and resources when cutting a tag.