### PR TITLE
Point KDM at release URL for release

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/dev-v2.7/data.json"
+	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/release-v2.7/data.json"
 	dataFile   = "data/data.json"
 )
 


### PR DESCRIPTION
Pointing to KDM release url in preparation for release.

`go generate ./...` did not modify any files when ran. 