### PR TITLE
fix the bug that delete_local_data is dropped 

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -687,8 +687,13 @@ func parseNodeDrainInput(clusterFile string, rkeConfig *v3.RancherKubernetesEngi
 		nodeDrainInput.GracePeriod = DefaultNodeDrainGracePeriod
 		update = true
 	} else {
-		// TODO: ghodssyaml.Marshal is losing the user provided value for GracePeriod, investigate why, till then assign the provided value explicitly
+		// add back user's value because ghodssyaml.Marshal drops the value due to the same field has different names in YAML tag and JSON tag
 		nodeDrainInput.GracePeriod = int(providedGracePeriod)
+	}
+
+	// add back user's value because ghodssyaml.Marshal drops the value due to the same field has different names in YAML tag and JSON tag
+	if val, ok := nodeDrainInputMap["delete_local_data"].(bool); ok {
+		nodeDrainInput.DeleteLocalData = val
 	}
 
 	if update {


### PR DESCRIPTION
fix the bug where the value of delete_local_data is dropped by the ghodssyaml.Marshal function due to the same field has different names in YAML tag and JSON tag

# Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
https://github.com/rancher/rke/issues/3412
https://github.com/rancher/rancher/issues/44564

# Problem

In the declaration of the type `NodeDrainInput` ([here](https://github.com/rancher/rke/blob/dbf3a46c7cc2e56f5a62d3a22c0bc1aca40b0da6/types/rke_types.go#L1062-L1076)), the name of the same field is different in the YAML format v.s. JSON format:
- ignore_daemonsets v.s. ignoreDaemonSets
- delete_local_data v.s. deleteLocalData
- grace_period v.s gracePeriod

In the [function parseNodeDrainInput](https://github.com/rancher/rke/blob/release/v1.5/cluster/cluster.go#L647),  RKE uses `ghodssyaml.Unmarshal` and `ghodssyaml.Marshal` to covert the user's config into the `NodeDrainInput` object. those two functions internally use ` json.Marshal` and ` json.Unmarshal` to do the convention.  However because the names of the same field are different, those values are dropped in the final output. This is also why there is [ inline comment](https://github.com/rancher/rke/blob/dbf3a46c7cc2e56f5a62d3a22c0bc1aca40b0da6/cluster/cluster.go#L690) about  `ghodssyaml.Marshal` is losing the user-provided value for GracePeriod.  

# Solution
 
Add the value of `delete_local_data` back if it is set in the cluster config file. 


# Testing
 

The fix is validated by using a local build of RKE from this PR and a config file that contains the `upgrade_strategy` from the linked issue 
```
upgrade_strategy:
  max_unavailable_worker: 1
  max_unavailable_controlplane: 1
  drain: true
  node_drain_input:
    force: false
    ignore_daemonsets: true
    delete_local_data: true
```

The following message in the output indicates the value `delete_local_data` is preserved:
`
INFO[0063] [controlplane] Processing controlplane hosts for upgrade 1 at a time 
INFO[0063] [controlplane] Parameters provided to drain command: "Force: false, IgnoreAllDaemonSets: true, DeleteEmptyDirData: true, Timeout: 2m0s, GracePeriodSeconds: -1" 
`
