### PR TITLE
[1.4.16] Feb 2024 patches: Release 1.4.16

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/dev-v2.7-2024-02-patches/data.json"
+	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/release-v2.7/data.json"
 	dataFile   = "data/data.json"
 )
 


### PR DESCRIPTION
This branch was branched off of the `release/v1.4.16` branch and then pointed at the KDM release URL.

note: ran `go generate ./...` but no changes were found.

Issue: https://github.com/rancher/rancher/issues/44628