### PR TITLE
Restart kube-apiserver in all CP nodes after changing the Pod Security Admission Configuration

### DIFF
--- a/cluster/reconcile.go
+++ b/cluster/reconcile.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/rancher/rke/docker"
@@ -488,19 +487,4 @@ func getTaintKey(taint v3.RKETaint) string {
 
 func getTaintValue(taint v3.RKETaint) string {
 	return fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect)
-}
-
-// RestartKubeAPIServerWhenConfigChanges restarts the kube-apiserver container on the control plane nodes
-// when changes are detected on the to-be-applied kube-api configuration. This is needed to handle the case
-// where changes happen on the generated admission-control-config-file but not on the kube-apiserver container
-func RestartKubeAPIServerWhenConfigChanges(ctx context.Context, kubeCluster, currentCluster *Cluster) error {
-	if currentCluster == nil {
-		return nil
-	}
-	if !reflect.DeepEqual(currentCluster.Services.KubeAPI, kubeCluster.Services.KubeAPI) {
-		for _, host := range kubeCluster.ControlPlaneHosts {
-			return services.RestartKubeAPI(ctx, host)
-		}
-	}
-	return nil
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -200,10 +200,6 @@ func ClusterUp(ctx context.Context, dialersOptions hosts.DialersOptions, flags c
 		return APIURL, caCrt, clientCert, clientKey, nil, err
 	}
 
-	if err := cluster.RestartKubeAPIServerWhenConfigChanges(ctx, kubeCluster, currentCluster); err != nil {
-		return APIURL, caCrt, clientCert, clientKey, nil, err
-	}
-
 	if err := kubeCluster.PrePullK8sImages(ctx); err != nil {
 		return APIURL, caCrt, clientCert, clientKey, nil, err
 	}


### PR DESCRIPTION
# Problem
 
In Rancher, enabling/changing PSACT on an RKE1 node-driver cluster doesn't restart the `kube-apiserver` container in all Control Plane Nodes.

The root cause is that RKE does not handle the restarting of the `kube-apiserver` container when the admission configuration file is changed properly: the current implementation restarts the container in only one of the CP nodes. 

# Solution

This PR fixes the issue that kube-apiserver does not restart in all CP nodes after changing the Pod Security Admission Configuration.

Now, a new environment variable RKE_ADMISSION_CONFIG_CHECKSUM whose value is the checksum of the content of the admission configuration file is added to the env list that is set in the `kube-apiserver` container configuration, so any changes in the admission configuration file will result in a change in the container's configuration. RKE will detect the changes during reconciliation and therefore restart the kube-apiserver container on all CP nodes. The cadence is controlled by the upgrade strategy in the cluster. 

This PR also drops the unnecessary appending of env var to the cluster object which shows in the cluster.rkestate file as the following:  
<img width="780" alt="Screenshot 2024-03-13 at 4 37 49 PM" src="https://github.com/rancher/rke/assets/6218999/496cf8ee-eb0f-479d-adb0-68d6ae141c29">


 
# Testing

To prepare for the test, I used the RKE binary built from this branch to provision a 3-node all-role cluster. 

Then I performed the following tests by editing the cluster.yml and running `rke up`; after each test case, I verified that  1) the kube-apiserver container is restarted in all three CP nodes and 2) the file `/etc/kubernetes/admission.yaml` or `/etc/kubernetes/audit-policy.yaml` is changed to match the cluster.yml in all three CP nodes:

case 1. add the admission configuration under `.services.kube-api.admission_configuration` 
case 2. change the above admission configuration 
case 3. drop the above admission configuration 
case 4. set `services.kube-api.pod_security_configuration` to `privileged`
case 5. change `services.kube-api.pod_security_configuration` to `restricted` 
case 6. add an audit log configuration under `.services.kube-api.audit_log`
case 7. change the above audit log configuration