### PR TITLE
[v1.5] add timeout to etcd member add

### DIFF
--- a/services/etcd_util.go
+++ b/services/etcd_util.go
@@ -56,6 +56,7 @@ func getEtcdClientV3(ctx context.Context, etcdHost *hosts.Host, localConnDialerF
 		Endpoints:   []string{"https://" + etcdHost.InternalAddress + ":2379"},
 		TLS:         tlsConfig,
 		DialOptions: []grpc.DialOption{grpc.WithContextDialer(wrapper(dialer))},
+		DialTimeout: 5 * time.Second,
 	}
 
 	return etcdclientv3.New(cfg)


### PR DESCRIPTION
# Issue: https://github.com/rancher/rancher/issues/45539

- Etcd client v3 kept retrying on member add vs v2 client used to return errors so we didn't have timeout earlier 
- DialTimeout alone doesn't suffice, also need to specify client request timeout with context
- Updated to close all etcd clients as v3 client uses grpc to connect to etcd, could leave us with leaks if not closed 