### PR TITLE
[v1.5] switch KDM branch to release-v2.8

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/dev-v2.8/data.json"
+	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/release-v2.8/data.json"
 	dataFile   = "data/data.json"
 )
 


### PR DESCRIPTION
switch KDM branch to release-v2.8

`go generate` does not generate any changes because [this PR](https://github.com/rancher/rke/pull/3541) has been merged 