### PR TITLE
[1.5.8] Switch KDM to the release channel 

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/dev-v2.8-2024-03-patches/data.json"
+	defaultURL = "https://releases.rancher.com/kontainer-driver-metadata/release-v2.8/data.json"
 	dataFile   = "data/data.json"
 )
 


### PR DESCRIPTION
`go generate .` does not produce any changes 