### PR TITLE
Avoid allocating empty strings in the Env slice

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -203,7 +203,7 @@ func (c *Cluster) BuildKubeAPIProcess(host *hosts.Host, serviceOptions v3.Kubern
 		"tls-private-key-file":          pki.GetKeyPath(pki.KubeAPICertName),
 	}
 	CommandArrayArgs := make(map[string][]string, len(c.Services.KubeAPI.ExtraArgsArray))
-	Env := make([]string, len(c.Services.KubeAPI.ExtraEnv))
+	var Env []string
 
 	if len(c.CloudProvider.Name) > 0 {
 		CommandArgs["cloud-config"] = cloudConfigFileName
@@ -1267,6 +1267,10 @@ func getUniqStringList(l []string) []string {
 	m := map[string]bool{}
 	ul := []string{}
 	for _, k := range l {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
 		if _, ok := m[k]; !ok {
 			m[k] = true
 			ul = append(ul, k)

--- a/cluster/plan_test.go
+++ b/cluster/plan_test.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getUniqStringList(t *testing.T) {
+	type args struct {
+		l []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			"contain strings with only spaces",
+			args{
+				[]string{" ", "key1=value1", "   ", "key2=value2"},
+			},
+			[]string{"key1=value1", "key2=value2"},
+		},
+		{
+			"contain strings with trailing or leading spaces",
+			args{
+				[]string{"  key1=value1", "key1=value1  ", "  key2=value2   "},
+			},
+			[]string{"key1=value1", "key2=value2"},
+		},
+		{
+			"contain duplicated strings",
+			args{
+				[]string{"", "key1=value1", "key1=value1", "key2=value2"},
+			},
+			[]string{"key1=value1", "key2=value2"},
+		},
+		{
+			"contain empty string",
+			args{
+				[]string{"", "key1=value1", "", "key2=value2"},
+			},
+			[]string{"key1=value1", "key2=value2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, getUniqStringList(tt.args.l), "getUniqStringList(%v)", tt.args.l)
+		})
+	}
+}

--- a/scripts/integration
+++ b/scripts/integration
@@ -90,6 +90,25 @@ nodes:
 - address: rke-node-${node}
   role: [etcd, controlplane, worker]
   user: ubuntu
+services:
+  etcd:
+    extra_env:
+      - TEST_VAR=etcd
+  kubeproxy:
+    extra_env:
+      - TEST_VAR=kube-proxy
+  scheduler:
+    extra_env:
+      - TEST_VAR=scheduler
+  kubelet:
+    extra_env:
+      - TEST_VAR=kubelet
+  kube-controller:
+    extra_env:
+      - TEST_VAR=kube-controller
+  kube-api:
+    extra_env:
+    - TEST_VAR=kube-api
 EOF
 
     if [ "x${NETWORK_PLUGIN}" != "x" ]; then


### PR DESCRIPTION
https://github.com/rancher/rke/issues/3587
https://github.com/rancher/rancher/issues/45645

Problem:
Previously, we declared the Env slice with the size of the `c.Services.KubeAPI.ExtraEnv` field, which leads to empty strings at the beginning of the Env slice because we use Golang's append function to add new elements, and Docker is not happy with that. 

Fix:
We fix this issue by declaring the Env variable as an empty slice. 
We also enhance the `getUniqStringList` function to properly trim leading and trailing spaces in each element and to ignore empty strings.  
We add unit tests for  the `getUniqStringList` function  and update the integration tests. 


Dev validation:
Compile the code locally and run `rke up` succeeds with the following section in cluster.yaml file which failed before the fixing:
 
```
services:
  kube-api:
    extra_env:
    - TEST_VAR=test
```
