### PR TITLE
fix: fix slice init length

### DIFF
--- a/pki/util.go
+++ b/pki/util.go
@@ -506,8 +506,8 @@ func DeepEqualIPsAltNames(oldIPs, newIPs []net.IP) bool {
 	if len(oldIPs) != len(newIPs) {
 		return false
 	}
-	oldIPsStrings := make([]string, len(oldIPs))
-	newIPsStrings := make([]string, len(newIPs))
+	oldIPsStrings := make([]string, 0, len(oldIPs))
+	newIPsStrings := make([]string, 0, len(newIPs))
 	for i := range oldIPs {
 		oldIPsStrings = append(oldIPsStrings, oldIPs[i].String())
 		newIPsStrings = append(newIPsStrings, newIPs[i].String())


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(oldIPs) and len(newIPs) rather than initializing the length of this slice.

The only demo: https://go.dev/play/p/q1BcVCmvidW