### PR TITLE
Security issue with snapshot integrity verification

### DIFF
--- a/cluster/plan.go
+++ b/cluster/plan.go
@@ -2,7 +2,7 @@ package cluster
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -1270,7 +1270,7 @@ func (c *Cluster) getDefaultKubernetesServicesOptions(osType string) (v3.Kuberne
 }
 
 func getStringChecksum(config string) string {
-	configByteSum := md5.Sum([]byte(config))
+	configByteSum := sha256.Sum256([]byte(config))
 	return fmt.Sprintf("%x", configByteSum)
 }
 

--- a/services/etcd.go
+++ b/services/etcd.go
@@ -848,7 +848,7 @@ func GetEtcdSnapshotChecksum(ctx context.Context, etcdHost *hosts.Host, prsMap m
 	imageCfg := &container.Config{
 		Cmd: []string{
 			"sh", "-c", strings.Join([]string{
-				" if [ -f '", snapshotPath, "' ]; then md5sum '", snapshotPath, "' | cut -f1 -d' ' | tr -d '\n'; else echo 'snapshot file does not exist' >&2; fi"}, ""),
+				" if [ -f '", snapshotPath, "' ]; then sha256sum '", snapshotPath, "' | cut -f1 -d' ' | tr -d '\n'; else echo 'snapshot file does not exist' >&2; fi"}, ""),
 		},
 		Image: alpineImage,
 	}


### PR DESCRIPTION
Issue #3669

MD5 is not secure for file integrity verification: https://docs.datadoghq.com/code_analysis/static_analysis_rules/go-security/import-md5/

Changes:  
Replaced `md5sum` with `sha256sum` for calculating snapshot checksums