### PR TITLE
updated dev version to v1.7.99

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -90,7 +90,7 @@ func readFile(file string) ([]byte, error) {
 	return os.ReadFile(file)
 }
 
-const RKEVersionDev = "v1.6.99"
+const RKEVersionDev = "v1.7.99"
 
 func initAddonTemplates(data kdm.Data) {
 	K8sVersionToTemplates = data.K8sVersionedTemplates


### PR DESCRIPTION
- the current 1.6.99 dev version is causing the rc rke versions to have 1.27.x k8s version as supported in release notes.
https://github.com/rancher/rke/releases/tag/v1.7.0-rc.5