### PR TITLE
Revert commit and fix CI for v1.7.3 release

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.58
+          verify: false
       - name: Run CI
         run: |
           ./scripts/ci

--- a/pki/util.go
+++ b/pki/util.go
@@ -506,8 +506,8 @@ func DeepEqualIPsAltNames(oldIPs, newIPs []net.IP) bool {
 	if len(oldIPs) != len(newIPs) {
 		return false
 	}
-	oldIPsStrings := make([]string, 0, len(oldIPs))
-	newIPsStrings := make([]string, 0, len(newIPs))
+	oldIPsStrings := make([]string, len(oldIPs))
+	newIPsStrings := make([]string, len(newIPs))
 	for i := range oldIPs {
 		oldIPsStrings = append(oldIPsStrings, oldIPs[i].String())
 		newIPsStrings = append(newIPsStrings, newIPs[i].String())


### PR DESCRIPTION
There was a bump in the go linter action (golangci-lint) action that defaults configuration verification to true, which unexpectedly caused the release pipeline to fail.

This PR sets the verification to the previous default of false.

Because there's a commit we don't want to release in this cycle, we also have to revert it to get the repo in the same state as the latest RC tag (`v1.7.3-rc.1`).