### PR TITLE
[release/v1.6] Reapply "fix: fix slice init length (#3695)"

### DIFF
--- a/pki/util.go
+++ b/pki/util.go
@@ -506,8 +506,8 @@ func DeepEqualIPsAltNames(oldIPs, newIPs []net.IP) bool {
 	if len(oldIPs) != len(newIPs) {
 		return false
 	}
-	oldIPsStrings := make([]string, len(oldIPs))
-	newIPsStrings := make([]string, len(newIPs))
+	oldIPsStrings := make([]string, 0, len(oldIPs))
+	newIPsStrings := make([]string, 0, len(newIPs))
 	for i := range oldIPs {
 		oldIPsStrings = append(oldIPsStrings, oldIPs[i].String())
 		newIPsStrings = append(newIPsStrings, newIPs[i].String())


### PR DESCRIPTION
This reverts commit c6758c134d52697b533809b04ba07b18fa86a665.

Re-applying the original commit after a release.

This was reverted in https://github.com/rancher/rke/pull/3791 to allow fixing a CI issue and otherwise release the same thing as the previous rc that came before the reverted commit.