### PR TITLE
[release/v1.7] Reapply "fix: fix slice init length (#3785)"

### DIFF
--- a/pki/util.go
+++ b/pki/util.go
@@ -506,8 +506,8 @@ func DeepEqualIPsAltNames(oldIPs, newIPs []net.IP) bool {
 	if len(oldIPs) != len(newIPs) {
 		return false
 	}
-	oldIPsStrings := make([]string, len(oldIPs))
-	newIPsStrings := make([]string, len(newIPs))
+	oldIPsStrings := make([]string, 0, len(oldIPs))
+	newIPsStrings := make([]string, 0, len(newIPs))
 	for i := range oldIPs {
 		oldIPsStrings = append(oldIPsStrings, oldIPs[i].String())
 		newIPsStrings = append(newIPsStrings, newIPs[i].String())


### PR DESCRIPTION
This reverts commit 1c68ad08a9adf5c426e1b61035f9885390342ee9.

Re-applying the original commit after a release.

This was reverted in https://github.com/rancher/rke/pull/3790 to allow fixing a CI issue and otherwise release the same thing as the previous rc that came before the reverted commit.