### PR TITLE
[1.8] Add the same paths-ignore to the test-cni workflow as the one in the main workflow

### DIFF
--- a/.github/workflows/test-cni.yaml
+++ b/.github/workflows/test-cni.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - '**'
+    paths-ignore:
+      - '**.md'
+      - 'CODEOWNERS'
+      - 'LICENSE'
+      - 'docs/**'
 
 jobs:
   integration-cni-tests:


### PR DESCRIPTION
Currently, the workflow test-cni is triggered to run on the PR that contains only no-code changes, such as on https://github.com/rancher/rke/pull/3835  ( see screenshot below). 

This PR adds the same paths-ignore to the test-cni workflow as the one in the [main workflow](https://github.com/rancher/rke/blob/release/v1.8/.github/workflows/workflow.yaml#L17-L21).

Note that it does not alter the rule that a set of workflows is required for a PR to be merged. 

<img width="977" alt="Screenshot 2025-04-22 at 12 46 08 PM" src="https://github.com/user-attachments/assets/747430f1-2c22-4b38-8ae9-b21bebef4075" />


