### PR TITLE
Updates deployListener() to contain docker output check compatable with Docker Enginer 28 and below

### DIFF
--- a/cluster/network.go
+++ b/cluster/network.go
@@ -905,7 +905,7 @@ func (c *Cluster) deployListener(ctx context.Context, host *hosts.Host, portList
 
 	logrus.Debugf("[network] Starting deployListener [%s] on host [%s]", containerName, host.Address)
 	if err := docker.DoRunContainer(ctx, host.DClient, imageCfg, hostCfg, containerName, host.Address, "network", c.PrivateRegistriesMap); err != nil {
-		if strings.Contains(err.Error(), "bind: address already in use") {
+		if strings.Contains(err.Error(), ": address already in use") {
 			logrus.Debugf("[network] Service is already up on host [%s]", host.Address)
 			return nil
 		}


### PR DESCRIPTION
For:
* https://github.com/rancher/rke/issues/3847
* https://github.com/rancher/rancher/issues/50352

**Docker Port Binding Error in Version 28.x Breaks ETCD and Control Plane Node Creation**

In version 28, Docker Engine changed the output format for port binding errors when an address is already in use.

**Docker version 27.1.2:**

`failed to bind port 0.0.0.0:22/tcp: Error starting userland proxy: listen tcp4 0.0.0.0:22: bind: address already in use.`

**Docker version 28.2.2:**

`failed to bind host port for 0.0.0.0:22:172.17.0.3:80/tcp: address already in use`

However, this breaks the creation of ETCD and Control Plane nodes due to [this line of code](https://github.com/rancher/rke/blob/release/v1.8/cluster/network.go#L908), which uses Docker’s error output to determine whether a service is already running. The new bind message format no longer starts with bind:, so the check fails.

This causes provisioning failures when attempting to spin up Control Plane or ETCD nodes on hosts running Docker 28.x:

`[Failed to start [rke-cp-port-listener] container on host [X.X.X.X]: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint rke-etcd-port-listener `

`[Failed to start [rke-cp-port-listener] container on host [X.X.X.X]: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint rke-etcd-port-listener `


**Currently, the only workarounds are**:

- Running rke up --disable-port-check (which doesn’t seem supported for Rancher-managed downstream clusters)
- Downgrading Docker Engine to version 27.x

✅ Proposed Fix

I've removed the "bind" prefix requirement in the error check, which makes the logic compatible with both Docker 28.x and earlier versions.