### PR TITLE
[v1.7] Updates deployListener() to contain docker output check compatable with Docker Enginer 28 and below

### DIFF
--- a/cluster/network.go
+++ b/cluster/network.go
@@ -905,7 +905,7 @@ func (c *Cluster) deployListener(ctx context.Context, host *hosts.Host, portList
 
 	logrus.Debugf("[network] Starting deployListener [%s] on host [%s]", containerName, host.Address)
 	if err := docker.DoRunContainer(ctx, host.DClient, imageCfg, hostCfg, containerName, host.Address, "network", c.PrivateRegistriesMap); err != nil {
-		if strings.Contains(err.Error(), "bind: address already in use") {
+		if strings.Contains(err.Error(), ": address already in use") {
 			logrus.Debugf("[network] Service is already up on host [%s]", host.Address)
 			return nil
 		}


### PR DESCRIPTION
Updates deployListener() to contain docker output check compatable with Docker Enginer 28 and below
Ref 
- https://github.com/rancher/rancher/issues/50925
- https://github.com/rancher/rke/issues/3867