### PR TITLE
[v1.8] upload rke extended images list on tag

### DIFF
--- a/scripts/create-imageslist.sh
+++ b/scripts/create-imageslist.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This script will create a txt file with RKE extended life images.
+set -e -x
+
+IMAGES_LIST_FILE="./build/bin/rke-extended-life-images.txt"
+
+# Ensure the build directory exists
+mkdir -p ./build/bin
+
+echo "Creating ${IMAGES_LIST_FILE}"
+
+# The command to generate a unique list of sorted images after removing noiro/aci images. 
+./bin/rke config --system-images --all | grep -Eo '^[^ ]+/.+' | grep -v '^noiro/' | sort | uniq > "$IMAGES_LIST_FILE"
+
+# Check if the command was successful
+if [ $? -ne 0 ]; then
+  echo "Non-zero exit code while running 'rke config --system-images --all'"
+  exit 1
+fi
+
+echo "Done creating ${IMAGES_LIST_FILE}"
+
+# Display the content of the generated file
+cat "$IMAGES_LIST_FILE"

--- a/scripts/package
+++ b/scripts/package
@@ -10,3 +10,4 @@ SUFFIX=""
 [ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 
 ./scripts/create-releasenote.sh
+./scripts/create-imageslist.sh


### PR DESCRIPTION
Artifacts under build/bin are already uploaded as artifacts: https://github.com/rancher/rke/blob/release/v1.8/.github/workflows/workflow.yaml#L109 
https://github.com/rancher/rke/blob/release/v1.8/.github/workflows/workflow.yaml#L130

Creating new file `rke-extended-life-images.txt` to avoid uploading it manually. See https://github.com/rancher/rke/releases/download/v1.8.7/rke-extended-life-images.txt for reference. 